### PR TITLE
Add "cli-" prefix handling to fenced code

### DIFF
--- a/content/minfraud/setup.mdx
+++ b/content/minfraud/setup.mdx
@@ -18,6 +18,26 @@ location, but that’s not gonna cut it. If you want to report on those retentio
 rates, lifetime values, or repeat behaviors by geo, you need something you can
 query with SQL, something that lives in your data warehouse.
 
+<CodeSet>
+
+```cli-ruby
+echo "I am Ruby"
+```
+
+```cli-javascript
+echo "I am Typescript"
+```
+
+```cli-csharp
+echo "I am C#"
+```
+
+```cli-go
+echo "I am Go"
+```
+
+</CodeSet>
+
 
 <CodeSet>
 

--- a/gatsby/src/components/CodeSet.tsx
+++ b/gatsby/src/components/CodeSet.tsx
@@ -12,6 +12,10 @@ const getHumanReadable = (className: string): string  => languages
   .find(language => `language-${language.id}` === className)?.label
     || className.replace('language-', '');
 
+export const extractLanguage = (className: string): string => className
+  .startsWith('language-cli-') ? className.replace('cli-', '') : className;
+
+
 const CodeSet: React.FC = (props) => {
   const { isClient, key } = useIsClient();
   const { dispatch, context } = React.useContext(Store);
@@ -23,10 +27,10 @@ const CodeSet: React.FC = (props) => {
   const orderedChildren = React.Children.toArray(props.children).sort((a,b) => {
     if (React.isValidElement(a) && React.isValidElement(b)) {
       const indexA = languages.findIndex(element =>
-        `language-${element.id}` === a.props.children.props.className
+        `language-${element.id}` === extractLanguage(a.props.children.props.className)
       );
       const indexB = languages.findIndex(element =>
-        `language-${element.id}` === b.props.children.props.className
+        `language-${element.id}` === extractLanguage(b.props.children.props.className)
       );
 
       if (indexA - indexB > 0) {
@@ -43,7 +47,7 @@ const CodeSet: React.FC = (props) => {
 
   const orderedLanguages = React.Children.map(orderedChildren, child => {
     if (React.isValidElement(child)) {
-      return child.props.children.props.className;
+      return extractLanguage(child.props.children.props.className);
     }
   });
 
@@ -78,7 +82,7 @@ const CodeSet: React.FC = (props) => {
       {
         React.Children.map(orderedChildren, child => {
           if (React.isValidElement(child)) {
-            const className = child.props.children.props.className;
+            const className = extractLanguage(child.props.children.props.className);
             return (
               <button
                 className={`
@@ -93,7 +97,7 @@ const CodeSet: React.FC = (props) => {
                 }}
                 title={`View ${activeLanguage} code`}
               >
-                {getHumanReadable(className)}
+                {getHumanReadable(extractLanguage(className))}
               </button>
             );
           }
@@ -110,7 +114,7 @@ const CodeSet: React.FC = (props) => {
     >
       {React.Children.map(orderedChildren, child => {
         if (React.isValidElement(child)) {
-          if (child.props.children.props.className === activeLanguage) {
+          if (extractLanguage(child.props.children.props.className) === activeLanguage) {
             return wrapCodeExample(
               (
                 <>

--- a/gatsby/src/components/Mdx/Pre/Pre.tsx
+++ b/gatsby/src/components/Mdx/Pre/Pre.tsx
@@ -32,6 +32,9 @@ interface IPre {
   nav?: React.ReactElement<React.HTMLProps<HTMLElement>>;
 }
 
+const extractCli = (className: string): string => className
+  .startsWith('language-cli-') ? 'language-cli' : className;
+
 const Pre: React.FC<React.HTMLProps<HTMLPreElement> & IPre> = (props) => {
   const { hasWrapper = true } = props;
 
@@ -55,11 +58,13 @@ const Pre: React.FC<React.HTMLProps<HTMLPreElement> & IPre> = (props) => {
   const child =
     React.Children.toArray(props.children)[0] as React.ReactElement;
 
+  const extractedClassName = extractCli(child.props.className);
+
   const language = languages.find(
-    language => `language-${language.id}` === child.props.className
+    language => `language-${language.id}` === extractedClassName
   ) || {
-    id: child.props.className.replace('language-', ''),
-    label: child.props.className.replace('language-', ''),
+    id: extractedClassName.replace('language-', ''),
+    label: extractedClassName.replace('language-', ''),
     prismSettings: languages.find(
       language => language.id === '*'
     )?.prismSettings,


### PR DESCRIPTION
This allows us to have code samples that are cli-based, but are labelled as a different language.  Use-cases include displaying cli commands that are language specific, ie running `yarn install` for javascript/typescript code examples