### PR TITLE
Codeset language selection doesn't cause content to shift around

### DIFF
--- a/gatsby/src/components/CodeSet.module.scss
+++ b/gatsby/src/components/CodeSet.module.scss
@@ -1,14 +1,5 @@
 @import '../styles/variables';
 
-.wrapper {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 0 var(--mm-spacing);
-  @include pattern;
-}
-
 .nav {
   background-color: #3c3b62;
   border-radius: var(--mm-border-radius) var(--mm-border-radius) 0 0;

--- a/gatsby/src/components/CodeSet.module.scss
+++ b/gatsby/src/components/CodeSet.module.scss
@@ -1,5 +1,14 @@
 @import '../styles/variables';
 
+.wrapper {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 var(--mm-spacing);
+  @include pattern;
+}
+
 .nav {
   background-color: #3c3b62;
   border-radius: var(--mm-border-radius) var(--mm-border-radius) 0 0;

--- a/gatsby/src/components/CodeSet.tsx
+++ b/gatsby/src/components/CodeSet.tsx
@@ -110,25 +110,20 @@ const CodeSet: React.FC = (props) => {
 
   return (
     <div
+      className={styles.wrapper}
       key={key}
     >
+      {nav}
       {React.Children.map(orderedChildren, child => {
         if (React.isValidElement(child)) {
-          if (extractLanguage(child.props.children.props.className) === activeLanguage) {
-            return wrapCodeExample(
-              (
-                <>
-                  {nav}
-                  <Pre
-                    {...child.props}
-                    hasWrapper={false}
-                  />
-                </>
-              ),
-              undefined,
-              key,
-            );
-          }
+          return (
+                <Pre
+                  {...child.props}
+                  hasWrapper={false}
+                  hidden={extractLanguage(child.props.children.props.className) !== activeLanguage}
+                  key
+                />
+            )
         }
       })}
     </div>

--- a/gatsby/src/components/CodeSet.tsx
+++ b/gatsby/src/components/CodeSet.tsx
@@ -6,7 +6,7 @@ import { languages } from '../languages';
 import { Store } from '../store';
 import styles from './CodeSet.module.scss';
 import Pre from './Mdx/Pre';
-import { wrapCodeExample } from './Mdx/Pre/Pre';
+import Wrapper from './Mdx/Pre/Wrapper';
 
 const getHumanReadable = (className: string): string  => languages
   .find(language => `language-${language.id}` === className)?.label
@@ -109,9 +109,7 @@ const CodeSet: React.FC = (props) => {
   if ( !isClient ) return null;
 
   return (
-    <div
-      className={styles.wrapper}
-      key={key}
+    <Wrapper
     >
       {nav}
       {React.Children.map(orderedChildren, child => {
@@ -126,7 +124,7 @@ const CodeSet: React.FC = (props) => {
             )
         }
       })}
-    </div>
+    </Wrapper>
   );
 };
 

--- a/gatsby/src/components/Mdx/Pre/Pre.module.scss
+++ b/gatsby/src/components/Mdx/Pre/Pre.module.scss
@@ -1,14 +1,5 @@
 @import '../styles/variables';
 
-.wrapper {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 0 var(--mm-spacing);
-  @include pattern;
-}
-
 .container {
   display: inline-block;
   position: relative;

--- a/gatsby/src/components/Mdx/Pre/Pre.module.scss
+++ b/gatsby/src/components/Mdx/Pre/Pre.module.scss
@@ -51,3 +51,9 @@
 .container pre {
   margin-top: 0 !important;
 }
+
+.hidden {
+  max-height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}

--- a/gatsby/src/components/Mdx/Pre/Pre.tsx
+++ b/gatsby/src/components/Mdx/Pre/Pre.tsx
@@ -9,22 +9,7 @@ import Button from './Button';
 import Code from './Code';
 import Message, { State as MessageState } from './Message';
 import styles from './Pre.module.scss';
-
-export const wrapCodeExample = (
-  codeExample: React.ReactElement,
-  className: string | undefined,
-  key: string,
-): React.ReactElement => (
-  <div
-    className={classNames(
-      className,
-      styles.wrapper,
-    )}
-    key={key}
-  >
-    {codeExample}
-  </div>
-);
+import Wrapper from './Wrapper';
 
 interface IPre {
   hasWrapper?: boolean;
@@ -143,11 +128,11 @@ const Pre: React.FC<React.HTMLProps<HTMLPreElement> & IPre> = (props) => {
   );
 
   if (hasWrapper) {
-    return wrapCodeExample(
-      codeExample,
-      props.className,
-      key
-    );
+    return (
+      <Wrapper className={props.className} key={key}>
+        {codeExample}
+      </Wrapper>
+    )
   }
 
   return codeExample;

--- a/gatsby/src/components/Mdx/Pre/Pre.tsx
+++ b/gatsby/src/components/Mdx/Pre/Pre.tsx
@@ -96,7 +96,7 @@ const Pre: React.FC<React.HTMLProps<HTMLPreElement> & IPre> = (props) => {
 
   const codeExample = (
     <div
-      className={styles.container}
+      className={classNames(styles.container, props.hidden && styles.hidden)}
     >
       <div
         className={styles.toolbar}

--- a/gatsby/src/components/Mdx/Pre/Wrapper.module.scss
+++ b/gatsby/src/components/Mdx/Pre/Wrapper.module.scss
@@ -1,0 +1,10 @@
+@import '../styles/variables';
+
+.wrapper {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 var(--mm-spacing);
+  @include pattern;
+}

--- a/gatsby/src/components/Mdx/Pre/Wrapper.tsx
+++ b/gatsby/src/components/Mdx/Pre/Wrapper.tsx
@@ -1,0 +1,30 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import styles from './Wrapper.module.scss';
+
+interface IWrapper {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const Wrapper: React.FC<IWrapper> = (props) => {
+  return (
+    <div
+      className={classNames(
+        props.className,
+        styles.wrapper,
+      )}
+    >
+      {props.children}
+    </div>
+  );
+};
+
+Wrapper.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default Wrapper;


### PR DESCRIPTION
Fixes:
* Codeset language selection doesn't cause content to shift around
* Rendering flash when switching codeset languages