### PR TITLE
Fix ESLint TypeScript warnings

### DIFF
--- a/src/components/CodeSet.tsx
+++ b/src/components/CodeSet.tsx
@@ -27,10 +27,14 @@ const CodeSet: React.FC = (props) => {
   const orderedChildren = React.Children.toArray(props.children).sort((a,b) => {
     if (React.isValidElement(a) && React.isValidElement(b)) {
       const indexA = languages.findIndex(element =>
-        `language-${element.id}` === extractLanguage(a.props.children.props.className)
+        `language-${element.id}` === extractLanguage(
+          a.props.children.props.className
+        )
       );
       const indexB = languages.findIndex(element =>
-        `language-${element.id}` === extractLanguage(b.props.children.props.className)
+        `language-${element.id}` === extractLanguage(
+          b.props.children.props.className
+        )
       );
 
       if (indexA - indexB > 0) {
@@ -82,7 +86,9 @@ const CodeSet: React.FC = (props) => {
       {
         React.Children.map(orderedChildren, child => {
           if (React.isValidElement(child)) {
-            const className = extractLanguage(child.props.children.props.className);
+            const className = extractLanguage(
+              child.props.children.props.className
+            );
             return (
               <button
                 className={`
@@ -113,11 +119,12 @@ const CodeSet: React.FC = (props) => {
       {nav}
       {React.Children.map(orderedChildren, child => {
         if (React.isValidElement(child)) {
+          const { className } = child.props.children.props;
           return (
             <Pre
               {...child.props}
               hasWrapper={false}
-              hidden={extractLanguage(child.props.children.props.className) !== activeLanguage}
+              hidden={extractLanguage(className) !== activeLanguage}
               key={key}
             />
           );

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -25,6 +25,8 @@ interface ILayout {
   className?: string;
   description?: string;
   keywords?: string[];
+  // TODO - Add proper typing for `tableOfContents'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tableOfContents?: any;
   title: string;
   type?: 'geoip' | 'geolite' | 'minfraud';

--- a/src/components/Layout/Seo.tsx
+++ b/src/components/Layout/Seo.tsx
@@ -8,20 +8,11 @@
 import { graphql, useStaticQuery } from 'gatsby';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Helmet from 'react-helmet';
+import Helmet, { HelmetProps } from 'react-helmet';
 
-interface IMetaItem {
-  content: string;
-  name?: string;
-  property?: string;
-}
-
-export interface ISEO {
-  bodyAttributes?: any;
+export interface ISEO extends HelmetProps {
   description?: string;
   lang?: string;
-  meta?: IMetaItem[];
-  title: string;
 }
 
 const SEO: React.FC<ISEO> = (props) => {

--- a/src/components/Layout/sidebarItems.tsx
+++ b/src/components/Layout/sidebarItems.tsx
@@ -79,6 +79,7 @@ export const sidebarItems: IItem[] = [
                   {
                     className: styles['item-attribute'],
                     title: 'funds_remaining',
+                    // eslint-disable-next-line max-len
                     to: '/minfraud/api-reference#Response_Score__funds_remaining',
                   },
                   {

--- a/src/templates/ApiReference/ApiReference.tsx
+++ b/src/templates/ApiReference/ApiReference.tsx
@@ -12,13 +12,16 @@ import Schema from './Schema';
 import { ISchema } from './Schema/Schema';
 
 interface IApiReference {
-  // description: string;
-  // keywords: string[];
-  pageContext: any;
-  // specJson: unknown;
-  // tableOfContents: any;
-  // title: string;
-  // type?: 'geoip' | 'minfraud';
+  pageContext: {
+    description: string;
+    keywords: string[];
+    spec: unknown;
+    // TODO - Add type for `tableOfContents`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tableOfContents: any;
+    title: string;
+    type?: 'geoip' | 'minfraud';
+  };
 }
 
 const ApiReference: React.FC<IApiReference> = (props) => {
@@ -63,16 +66,18 @@ const ApiReference: React.FC<IApiReference> = (props) => {
 };
 
 ApiReference.propTypes = {
-  pageContext: PropTypes.any.isRequired,
-  // description: PropTypes.string.isRequired,
-  // keywords: PropTypes.arrayOf(PropTypes.any).isRequired,
-  // specJson: PropTypes.any.isRequired,
-  // tableOfContents: PropTypes.any.isRequired,
-  // title: PropTypes.string.isRequired,
-  // type: PropTypes.oneOf([
-  //   'geoip',
-  //   'minfraud',
-  // ]),
+  pageContext: PropTypes.exact({
+    description: PropTypes.string.isRequired,
+    keywords: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    spec: PropTypes.object.isRequired,
+    tableOfContents: PropTypes.any.isRequired,
+    title: PropTypes.string.isRequired,
+    type: PropTypes.oneOf([
+      'geoip',
+      'minfraud',
+    ] as const).isRequired,
+  }).isRequired,
+
 };
 
 export default ApiReference;

--- a/src/templates/ApiReference/Schema/Content/Properties.tsx
+++ b/src/templates/ApiReference/Schema/Content/Properties.tsx
@@ -94,6 +94,10 @@ Row.propTypes = {
   type: PropTypes.any,
 };
 
+// TODO - Add proper types for anything that uses `TempAny` type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TempAny = any;
+
 const renderObjectRows = (
   schema: OpenAPIV3.SchemaObject,
   schemaName: string,
@@ -112,7 +116,7 @@ const renderObjectRows = (
 
       const type = properties.type || (
         <>
-          {getRefAnchorLink((properties as any).$ref)}
+          {getRefAnchorLink((properties as TempAny).$ref)}
         </>
       );
 
@@ -122,7 +126,7 @@ const renderObjectRows = (
           format={properties.format && `(${properties.format})`}
           handleHightlightLines={handleHightlightLines}
           key={`row-${index}`}
-          lineNumbers={(properties as any)['x-line-numbers']}
+          lineNumbers={(properties as TempAny)['x-line-numbers']}
           name={name}
           schemaName={schemaName}
           type={type}
@@ -139,8 +143,8 @@ const renderArrayRows = (
   return (
     <Row
       description={schema.description}
-      format={(schema.items as any)?.$ref
-        && `<${(schema.items as any)?.$ref}>[]`}
+      format={(schema.items as TempAny)?.$ref
+        && `<${(schema.items as TempAny)?.$ref}>[]`}
       handleHightlightLines={handleHightlightLines}
       name="array"
       schemaName={schemaName}


### PR DESCRIPTION
In this PR, either ESLint TypeScript warnings are fixed or a TODO note + `eslint-disable-next-line` is added to address the issue later.