### PR TITLE
Fix Sass implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "gatsby-source-filesystem": "^2.3.34",
     "gatsby-transformer-sharp": "^2.5.17",
     "node-fetch": "^2.6.1",
-    "node-sass": "^4.14.1",
     "normalize.css": "^8.0.1",
     "openapi-types": "^7.0.1",
     "openapi3-ts": "^2.0.0",
@@ -69,6 +68,7 @@
   "devDependencies": {
     "@types/dompurify": "^2.0.4",
     "@types/jest": "^26.0.14",
+    "@types/sass": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
     "babel-eslint": "^10.1.0",
@@ -104,6 +104,7 @@
     "remark-preset-github": "^3.0.0",
     "remark-preset-lint-markdown-style-guide": "^3.0.1",
     "remark-preset-lint-recommended": "^4.0.1",
+    "sass": "^1.29.0",
     "stylelint": "^13.7.2",
     "stylelint-config-recommended": "^3.0.0",
     "stylelint-config-sass-guidelines": "^7.1.0",

--- a/src/components/CodeSet.module.scss
+++ b/src/components/CodeSet.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .nav {
   background-color: #3c3b62;

--- a/src/components/Layout/Footer.module.scss
+++ b/src/components/Layout/Footer.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .footer {
   background: rgb(46, 58, 71);
@@ -17,7 +17,7 @@
     top: 0;
     width: 100%;
 
-    @include pattern;
+    @include variables.pattern;
   }
 
   &::after {
@@ -117,7 +117,7 @@
   }
 }
 
-@include breakpoint('md') {
+@include variables.breakpoint('md') {
   .container {
     grid-template-columns: 1fr 1fr 1fr 1fr;
   }
@@ -143,7 +143,7 @@
   }
 }
 
-@include breakpoint('xl') {
+@include variables.breakpoint('xl') {
   .container {
     grid-template-columns: var(--mm-layout-sidebar-width) 1fr 1fr 1fr 1fr;
   }
@@ -193,7 +193,9 @@
   }
 }
 
-@include breakpoint('xxxl') {
-  margin: 0 auto;
-  max-width: 80%;
+@include variables.breakpoint('xxxl') {
+  .container {
+    // margin: 0 auto;
+    max-width: map-get(variables.$breakpoints, 'xxxl');
+  }
 }

--- a/src/components/Layout/Header.module.scss
+++ b/src/components/Layout/Header.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .header {
   background: var(--mm-color-background);
@@ -20,7 +20,7 @@
     top: 0;
     width: 100%;
 
-    @include pattern;
+    @include variables.pattern;
   }
 
   &::after {
@@ -54,14 +54,14 @@
   width: 100%;
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .search {
     margin-left: 110px;
     width: calc(100% - 290px);
   }
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .search {
     width: calc(100% - 558px);
   }
@@ -78,7 +78,7 @@
   z-index: 4;
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .toggle {
     display: none;
   }

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -1,5 +1,5 @@
-@import '../../styles/variables';
-@import '../../styles/global';
+@use '../../styles/variables';
+@use '../../styles/global';
 
 $transition: all 0.15s ease-out;
 
@@ -21,7 +21,7 @@ $transition: all 0.15s ease-out;
   transform: translate3d(100vw, 0, 0);
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   :root {
     --mm-layout-sidebar-width: 350px;
   }

--- a/src/components/Layout/SearchBar.module.scss
+++ b/src/components/Layout/SearchBar.module.scss
@@ -1,18 +1,18 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .searchbar {
   display: none;
   position: relative;
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .searchbar {
     display: inline-block;
     width: 100%;
   }
 }
 
-@media only screen and (max-width: map-get($breakpoints, 'lg')) {
+@media only screen and (max-width: map-get(variables.$breakpoints, 'lg')) {
   .searchbar--mobile-open {
     display: inline-block;
     left: 0;
@@ -34,7 +34,7 @@
   position: relative;
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .search-mobile {
     display: none;
   }

--- a/src/components/Layout/Sidebar.module.scss
+++ b/src/components/Layout/Sidebar.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .sidebar {
   background: var(--mm-color-sidebar);
@@ -149,7 +149,7 @@
   margin-bottom: 0;
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .sidebar {
     border-left: 0;
     border-right: 1px solid var(--mm-color-border);

--- a/src/components/Mdx/A.module.scss
+++ b/src/components/Mdx/A.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .a {
   align-items: center;

--- a/src/components/Mdx/Blockquote.module.scss
+++ b/src/components/Mdx/Blockquote.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .wrapper {
   border-left: 0;

--- a/src/components/Mdx/Code.module.scss
+++ b/src/components/Mdx/Code.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .code {
   background: #eee;

--- a/src/components/Mdx/H1.module.scss
+++ b/src/components/Mdx/H1.module.scss
@@ -1,7 +1,7 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .h1 {
-  @include heading;
+  @include variables.heading;
   font-size: 32px;
   margin: var(--mm-spacing);
   margin-top: 0;

--- a/src/components/Mdx/H2.module.scss
+++ b/src/components/Mdx/H2.module.scss
@@ -1,6 +1,6 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .h2 {
-  @include heading;
+  @include variables.heading;
   font-size: 28px;
 }

--- a/src/components/Mdx/H3.module.scss
+++ b/src/components/Mdx/H3.module.scss
@@ -1,6 +1,6 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .h3 {
-  @include heading;
+  @include variables.heading;
   font-size: 24px;
 }

--- a/src/components/Mdx/H4.module.scss
+++ b/src/components/Mdx/H4.module.scss
@@ -1,6 +1,6 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .h4 {
-  @include heading;
+  @include variables.heading;
   font-size: 18px;
 }

--- a/src/components/Mdx/H5.module.scss
+++ b/src/components/Mdx/H5.module.scss
@@ -1,6 +1,6 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .h5 {
-  @include heading;
+  @include variables.heading;
   font-size: 16px;
 }

--- a/src/components/Mdx/H6.module.scss
+++ b/src/components/Mdx/H6.module.scss
@@ -1,7 +1,7 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .h6 {
-  @include heading;
+  @include variables.heading;
   font-size: 16px;
   text-transform: uppercase;
 

--- a/src/components/Mdx/Hr.module.scss
+++ b/src/components/Mdx/Hr.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .hr {
   border: 0;
@@ -6,5 +6,5 @@
   height: 0;
   margin: var(--mm-spacing);
   padding: 0 !important;
-  @include max-width;
+  @include variables.max-width;
 }

--- a/src/components/Mdx/Li.module.scss
+++ b/src/components/Mdx/Li.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .li {
   margin-bottom: var(--mm-spacing) / 4;

--- a/src/components/Mdx/Ol.module.scss
+++ b/src/components/Mdx/Ol.module.scss
@@ -1,10 +1,10 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .ol {
   list-style-type: decimal;
   margin: var(--mm-spacing);
   padding-left: calc(var(--mm-spacing) / 2);
-  @include max-width;
+  @include variables.max-width;
 }
 
 .ol .ol {

--- a/src/components/Mdx/P.module.scss
+++ b/src/components/Mdx/P.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .p {
   color: var(--mm-color-primary-text);
@@ -6,5 +6,5 @@
   line-height: 26px;
   margin: var(--mm-spacing);
 
-  @include max-width;
+  @include variables.max-width;
 }

--- a/src/components/Mdx/Pre/Code.module.scss
+++ b/src/components/Mdx/Pre/Code.module.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable */
-@import '../styles/variables';
+@use '../styles/variables';
 
 $border-color: rgba(255, 255, 255, 0.2);
 $chars-color: rgba(255, 255, 255, 0.2);
@@ -384,7 +384,7 @@ $font-color: rgba(255, 255, 255, 0.3);
 
   overflow-y: hidden !important;
 
-  @include scrollbars();
+  @include variables.scrollbars();
 }
 
 .container--expanded .pre {

--- a/src/components/Mdx/Pre/Message.module.scss
+++ b/src/components/Mdx/Pre/Message.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .message {
   border-radius: var(--mm-border-radius) 0 0 var(--mm-border-radius);

--- a/src/components/Mdx/Pre/Pre.module.scss
+++ b/src/components/Mdx/Pre/Pre.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .container {
   display: inline-block;
@@ -27,7 +27,7 @@
   z-index: 3;
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .toolbar__buttons {
     display: block;
   }

--- a/src/components/Mdx/Pre/Wrapper.module.scss
+++ b/src/components/Mdx/Pre/Wrapper.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .wrapper {
   align-items: center;
@@ -6,5 +6,5 @@
   flex-direction: column;
   justify-content: center;
   margin: 0 var(--mm-spacing);
-  @include pattern;
+  @include variables.pattern;
 }

--- a/src/components/Mdx/Table.module.scss
+++ b/src/components/Mdx/Table.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .wrapper {
   display: flex;
@@ -21,7 +21,7 @@
   position: relative;
   z-index: 2;
 
-  @include scrollbars(rgba(0,0,0,0.2));
+  @include variables.scrollbars(rgba(0,0,0,0.2));
 }
 
 .table {

--- a/src/components/Mdx/Thead.module.scss
+++ b/src/components/Mdx/Thead.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .thead {
   border-bottom: 1px solid var(--mm-color-border);

--- a/src/components/Mdx/Ul.module.scss
+++ b/src/components/Mdx/Ul.module.scss
@@ -1,10 +1,10 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .ul {
   list-style-type: disc;
   margin: var(--mm-spacing);
   padding-left: calc(var(--mm-spacing) / 2);
-  @include max-width;
+  @include variables.max-width;
 }
 
 .ul .ul {

--- a/src/gatsby/gatsby-config/index.ts
+++ b/src/gatsby/gatsby-config/index.ts
@@ -1,6 +1,7 @@
 import { GatsbyConfig } from 'gatsby';
 import remarkExternalLinks from 'remark-external-links';
 import remarkSlug from 'remark-slug';
+import sass from 'sass';
 
 /**
  * The plugins below must come last in the ordering of the plugins because they
@@ -28,6 +29,7 @@ export default {
         cssLoaderOptions: {
           camelCase: true,
         },
+        implementation: sass,
         includePaths: [
           'src/styles',
         ],

--- a/src/pages/search-results.module.scss
+++ b/src/pages/search-results.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .loading {
   align-items: center;
@@ -26,7 +26,7 @@
   }
 }
 
-@include breakpoint('lg') {
+@include variables.breakpoint('lg') {
   .heading {
     font-size: 30px;
   }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,4 +1,4 @@
-@import './reset';
+@use './reset';
 
 :global {
   .fa-icon {

--- a/src/templates/ApiReference/ApiReference.module.scss
+++ b/src/templates/ApiReference/ApiReference.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 :root {
   --heading-height: 50px;
@@ -57,7 +57,7 @@
   text-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
   transform: translateX(-50%);
   vertical-align: middle;
-  @include pattern;
+  @include variables.pattern;
 
   &::before {
     border-radius: var(--mm-border-radius);
@@ -102,7 +102,7 @@
   height: 0;
   overflow: hidden;
   padding: 0 !important;
-  @include pattern;
+  @include variables.pattern;
 }
 
 .example--is-expanded {
@@ -123,7 +123,7 @@
   padding-bottom: 1px;
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .schema {
     display: grid;
     grid-template-areas:

--- a/src/templates/ApiReference/Schema/CodeExample.module.scss
+++ b/src/templates/ApiReference/Schema/CodeExample.module.scss
@@ -1,10 +1,10 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .example {
   height: 0;
   overflow: hidden;
   padding: 0 !important;
-  @include pattern;
+  @include variables.pattern;
 }
 
 .example--is-expanded {
@@ -18,7 +18,7 @@
   margin: 0;
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .example {
     grid-area: schema-example;
     height: auto;

--- a/src/templates/ApiReference/Schema/Content/Content.module.scss
+++ b/src/templates/ApiReference/Schema/Content/Content.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .description {
   line-height: 1.5em;
@@ -38,7 +38,7 @@
   text-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
   transform: translateX(-50%);
   vertical-align: middle;
-  @include pattern;
+  @include variables.pattern;
 
   &::before {
     border-radius: var(--mm-border-radius);
@@ -61,7 +61,7 @@
   transform: rotate(180deg);
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .body {
     grid-area: schema-body;
   }

--- a/src/templates/ApiReference/Schema/Content/Properties.module.scss
+++ b/src/templates/ApiReference/Schema/Content/Properties.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .row {
   border: 2px solid transparent;

--- a/src/templates/ApiReference/Schema/Heading.module.scss
+++ b/src/templates/ApiReference/Schema/Heading.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .heading {
   --heading-height: 50px;
@@ -41,7 +41,7 @@
   vertical-align: middle;
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .heading {
     grid-area: schema-heading;
   }

--- a/src/templates/ApiReference/Schema/Schema.module.scss
+++ b/src/templates/ApiReference/Schema/Schema.module.scss
@@ -1,10 +1,10 @@
-@import '../../styles/variables';
+@use '../../../styles/variables';
 
 .schema {
   width: 100%;
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .schema {
     display: grid;
     grid-template-areas:

--- a/src/templates/ApiReference/Schema/Type.module.scss
+++ b/src/templates/ApiReference/Schema/Type.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../../styles/variables';
 
 .type {
   background: rgba(60, 88, 99, 0.05);

--- a/src/templates/Page/Page.module.scss
+++ b/src/templates/Page/Page.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@use '../../styles/variables';
 
 .header {
   background: var(--mm-color-background);
@@ -9,13 +9,13 @@
 .heading {
   margin: 0;
   padding: 0;
-  @include max-width;
+  @include variables.max-width;
 }
 
 .meta {
   font-size: 14px;
   margin-top: var(--mm-spacing) / 2;
-  @include max-width;
+  @include variables.max-width;
 }
 
 .aside {
@@ -36,7 +36,7 @@
     top: 0;
     width: 100%;
 
-    @include pattern;
+    @include variables.pattern;
   }
 
   &::after {
@@ -49,7 +49,7 @@
   margin-top: 0;
 }
 
-@include breakpoint('xl') {
+@include variables.breakpoint('xl') {
   .article {
     display: grid;
     grid-template-areas:
@@ -72,7 +72,7 @@
   .aside {
     grid-area: aside;
     min-width: 700px;
-    @include max-width;
+    @include variables.max-width;
   }
 
   .content {
@@ -98,7 +98,7 @@
   }
 }
 
-@include breakpoint('xxl') {
+@include variables.breakpoint('xxl') {
   .article {
     grid-template-areas:
       'header aside'
@@ -145,7 +145,7 @@
   }
 }
 
-@include breakpoint('xxxl') {
+@include variables.breakpoint('xxxl') {
   .content {
     margin: 0 auto;
   }

--- a/src/templates/Page/TableOfContents.module.scss
+++ b/src/templates/Page/TableOfContents.module.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables';
+@use '../styles/variables';
 
 .heading {
   color: var(--mm-color-display-text);
@@ -107,7 +107,7 @@
   }
 }
 
-@include breakpoint('xl') {
+@include variables.breakpoint('xl') {
   .list {
     list-style-position: outside;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,6 +2715,13 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/sass@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.0.tgz#b41ac1c17fa68ffb57d43e2360486ef526b3d57d"
+  integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -3177,11 +3184,6 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
-
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -3558,11 +3560,6 @@ async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
-
-async-foreach@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
-  integrity sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=
 
 async-limiter@~1.0.0:
   version "1.0.1"
@@ -4149,13 +4146,6 @@ blob@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
 
 bluebird@^3.0.5, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
@@ -4749,7 +4739,7 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
-chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -4888,6 +4878,21 @@ cheerio@^1.0.0-rc.3:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.0.0, chokidar@^3.0.2, chokidar@^3.4.1, chokidar@^3.4.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
+  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -4906,21 +4911,6 @@ chokidar@^2.0.4, chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.0.0, chokidar@^3.0.2, chokidar@^3.4.1, chokidar@^3.4.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
-  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.5.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
@@ -5703,14 +5693,6 @@ cross-spawn@5.1.0, cross-spawn@^5.0.1:
   dependencies:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
-    which "^1.2.9"
-
-cross-spawn@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
-  integrity sha1-ElYDfsufDF9549bvE14wdwGEuYI=
-  dependencies:
-    lru-cache "^4.0.1"
     which "^1.2.9"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
@@ -8421,7 +8403,7 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-fstream@^1.0.0, fstream@^1.0.12:
+fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -9084,13 +9066,6 @@ gaxios@^2.1.0:
     is-stream "^2.0.0"
     node-fetch "^2.3.0"
 
-gaze@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
-  integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
-  dependencies:
-    globule "^1.0.0"
-
 gcp-metadata@^3.4.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-3.5.0.tgz#6d28343f65a6bbf8449886a0c0e4a71c77577055"
@@ -9247,7 +9222,7 @@ glob-slasher@^1.0.1:
     lodash.isobject "^2.4.1"
     toxic "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -9371,15 +9346,6 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
-
-globule@^1.0.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.3.2.tgz#d8bdd9e9e4eef8f96e245999a5dee7eb5d8529c4"
-  integrity sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==
-  dependencies:
-    glob "~7.1.1"
-    lodash "~4.17.10"
-    minimatch "~3.0.2"
 
 gonzales-pe@^4.0.3, gonzales-pe@^4.3.0:
   version "4.3.0"
@@ -10333,11 +10299,6 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
-in-publish@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
-  integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -11626,11 +11587,6 @@ jpeg-js@^0.4.0:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.2.tgz#8b345b1ae4abde64c2da2fe67ea216a114ac279d"
   integrity sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==
 
-js-base64@^2.1.8:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -12541,7 +12497,7 @@ lodash.values@^2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -13069,7 +13025,7 @@ memorystream@^0.3.1:
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
   integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
-meow@^3.3.0, meow@^3.7.0:
+meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
@@ -13253,7 +13209,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -13466,7 +13422,7 @@ name-all-modules-plugin@^1.0.1:
   resolved "https://registry.yarnpkg.com/name-all-modules-plugin/-/name-all-modules-plugin-1.0.1.tgz#0abfb6ad835718b9fb4def0674e06657a954375c"
   integrity sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w=
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.1:
+nan@^2.12.1, nan@^2.14.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -13622,24 +13578,6 @@ node-forge@^0.10.0, node-forge@^0.9.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-gyp@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
-  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
-  dependencies:
-    fstream "^1.0.0"
-    glob "^7.0.3"
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2 || 3 || 4"
-    osenv "0"
-    request "^2.87.0"
-    rimraf "2"
-    semver "~5.3.0"
-    tar "^2.0.0"
-    which "1"
-
 node-gyp@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.0.tgz#cb8aed7ab772e73ad592ae0c71b0e3741099fe39"
@@ -13717,29 +13655,6 @@ node-releases@^1.1.61:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.61.tgz#707b0fca9ce4e11783612ba4a2fcba09047af16e"
   integrity sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==
 
-node-sass@^4.14.1:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
-  integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash "^4.17.15"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.13.2"
-    node-gyp "^3.8.0"
-    npmlog "^4.0.0"
-    request "^2.88.0"
-    sass-graph "2.2.5"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
-
 noms@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
@@ -13752,13 +13667,6 @@ noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
   integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
-
-"nopt@2 || 3":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
-  dependencies:
-    abbrev "1"
 
 nopt@^4.0.3:
   version "4.0.3"
@@ -13871,7 +13779,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -14232,7 +14140,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4:
+osenv@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -17376,7 +17284,7 @@ request-promise-native@^1.0.8:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.83.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@^2.83.0, request@^2.87.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -17770,16 +17678,6 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sass-graph@2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.5.tgz#a981c87446b8319d96dce0671e487879bd24c2e8"
-  integrity sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==
-  dependencies:
-    glob "^7.0.0"
-    lodash "^4.0.0"
-    scss-tokenizer "^0.2.3"
-    yargs "^13.3.2"
-
 sass-loader@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
@@ -17790,6 +17688,13 @@ sass-loader@^7.3.1:
     neo-async "^2.5.0"
     pify "^4.0.1"
     semver "^6.3.0"
+
+sass@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.29.0.tgz#ec4e1842c146d8ea9258c28c141b8c2b7c6ab7f1"
+  integrity sha512-ZpwAUFgnvAUCdkjwPREny+17BpUj8nh5Yr6zKPGtLNTLrmtoRYIjm7njP24COhjJldjwW1dcv52Lpf4tNZVVRA==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 sax@>=0.6.0, sax@~1.2.4:
   version "1.2.4"
@@ -17853,14 +17758,6 @@ schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
     "@types/json-schema" "^7.0.5"
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
-
-scss-tokenizer@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
-  integrity sha1-jrBtualyMzOCTT9VMGQRSYR85dE=
-  dependencies:
-    js-base64 "^2.1.8"
-    source-map "^0.4.2"
 
 section-matter@^1.0.0:
   version "1.0.0"
@@ -17937,11 +17834,6 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 send@0.17.1:
   version "0.17.1"
@@ -18401,13 +18293,6 @@ source-map@0.7.3, source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-source-map@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
-  dependencies:
-    amdefine ">=0.0.4"
-
 source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -18623,13 +18508,6 @@ static-site-generator-webpack-plugin@^3.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
-
-stdout-stream@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.1.tgz#5ac174cdd5cd726104aa0c0b2bd83815d8d535de"
-  integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
-  dependencies:
-    readable-stream "^2.0.1"
 
 stealthy-require@^1.1.1:
   version "1.1.1"
@@ -19342,15 +19220,6 @@ tar-stream@^2.0.0, tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
-
 tar@^4.3.0:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -19762,13 +19631,6 @@ trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
-
-"true-case-path@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.3.tgz#f813b5a8c86b40da59606722b144e3225799f47d"
-  integrity sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
-  dependencies:
-    glob "^7.1.2"
 
 "true-case-path@^2.2.1":
   version "2.2.1"
@@ -21038,7 +20900,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.14, which@^1.2.9, which@^1.3.1:
+which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
`node-sass` is has been deprecated. This PR changes the implementation of `gatsby-plugin-sass` to use Dart Sass.