### PR TITLE
Fix warning during `yarn develop`

### DIFF
--- a/src/gatsby/gatsby-node/createPages.ts
+++ b/src/gatsby/gatsby-node/createPages.ts
@@ -6,6 +6,8 @@ import createMdxPages from './pages/createMdxPages';
 export const createPages: GatsbyNode['createPages'] = async (
   props: CreatePagesArgs
 ) => {
-  await createMdxPages(props);
-  await createApiSpecPages(props);
+  await Promise.all([
+    createMdxPages(props),
+    createApiSpecPages(props),
+  ]);
 };

--- a/src/gatsby/gatsby-node/pages/createMdxPages.ts
+++ b/src/gatsby/gatsby-node/pages/createMdxPages.ts
@@ -12,37 +12,39 @@ const queries = [
   pageQuery,
 ];
 
-const createMdxPages = async (args: CreatePagesArgs): Promise<void> => {
+const createMdxPages = async (args: CreatePagesArgs): Promise<any> => {
   const { actions, graphql, reporter } = args;
   const { createPage } = actions;
 
-  queries.forEach(async (query) => {
-    const result = await query(graphql);
+  return Promise.all(
+    queries.map(async (query) => {
+      const result = await query(graphql);
 
-    if (result.errors) {
-      reporter.panicOnBuild('🚨 ERROR: error!');
-      console.log(result.errors);
-      throw new Error(`🚨 ERROR: Loading "${query.name}" query`);
-    }
-
-    if (!result.data) {
-      reporter.panicOnBuild('🚨 ERROR: No data!');
-      throw new Error('🚨 ERROR: No data!');
-    }
-
-    result.data.allMdx.nodes.forEach((node: IBaseQuery) => {
-      if (
-        process.env.gatsby_executing_command === 'develop'
-        || !node.frontmatter.draft
-      ) {
-        createPage({
-          component: node.fileAbsolutePath,
-          context: node,
-          path: node.fields.slug,
-        });
+      if (result.errors) {
+        reporter.panicOnBuild('🚨 ERROR: error!');
+        console.log(result.errors);
+        throw new Error(`🚨 ERROR: Loading "${query.name}" query`);
       }
-    });
-  });
+
+      if (!result.data) {
+        reporter.panicOnBuild('🚨 ERROR: No data!');
+        throw new Error('🚨 ERROR: No data!');
+      }
+
+      result.data.allMdx.nodes.forEach((node: IBaseQuery) => {
+        if (
+          process.env.gatsby_executing_command === 'develop'
+          || !node.frontmatter.draft
+        ) {
+          createPage({
+            component: node.fileAbsolutePath,
+            context: node,
+            path: node.fields.slug,
+          });
+        }
+      });
+    })
+  );
 };
 
 export default createMdxPages;


### PR DESCRIPTION
Ensures that all `async` lifecycle methods are wrapped in `Promise.all()` to prevent warnings.

See https://www.gatsbyjs.com/docs/debugging-async-lifecycles/