### PR TITLE
Make copyedit fixes to 'Evaluate a transaction' and 'minFraud Legacy'

### DIFF
--- a/content/minfraud/evaluate-a-transaction.mdx
+++ b/content/minfraud/evaluate-a-transaction.mdx
@@ -108,7 +108,7 @@ gem 'minfraud'
 ### 3. Create a minFraud client object
 
 To interact with our API, you need to create a new client object. For this you
-will need your MaxMind account ID and license key:
+will need [your MaxMind account ID and license key](https://www.maxmind.com/en/my_license_key):
 
 <CodeSet>
 
@@ -148,7 +148,7 @@ end
 ### 4. Create a transaction object
 
 The transaction object represents a customer's transaction that you are sending
-to the minFraud service for evaluation. There are not any mandatory fields, but
+to the minFraud service for evaluation. There are no mandatory fields, but
 including [more information](/minfraud/evaluate-a-transaction#full-examples)
 about the transaction improves the accuracy of the transaction's evaluation.
 The following examples use the recommended minimum amount of information you

--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -44,8 +44,8 @@ you.
 If you are using our minFraud transaction fraud detection service, we also
 encourage you to use our
 [report transaction service](/minfraud/report-a-transaction/). By reporting
-instances of fraud to us, you can help us tune our algorithms further, reducing
-fraud even more in the future.
+false positives and instances of fraud to us, you can help us refine our algorithms, so we can reduce
+false positives and catch more fraud.
 
 ## Device Tracking Add-on
 
@@ -67,7 +67,7 @@ The URI for this service is `https://minfraud.maxmind.com/minfraud/v1.0/legacy`.
 The `minfraud.maxmind.com` hostname automatically picks the data center
 geographically closest to you.
 
-## Security
+### Security
 
 The API is only available via HTTPS. If you attempt to access this service via
 HTTP, you will receive a `403 Forbidden` HTTP response.
@@ -215,12 +215,12 @@ longer than the longest valid representation of an IPv6 address.
       <tr>
          <td>binName</td>
          <td>string (255)</td>
-         <td>The name of the bank which issued the credit card, based on the BIN number. This is used to verify that cardholder is in possession of credit card. You must set the <strong>bin</strong> field if you set this one.</td>
+         <td>The name of the bank which issued the credit card as provided by the end-user who initiated the event. This is used to verify that cardholder is in possession of credit card. You must set the <strong>bin</strong> field if you set this one.</td>
       </tr>
       <tr>
          <td>binPhone</td>
          <td>string (255)</td>
-         <td>The customer service phone number listed on the back of the credit card. This is used to verify that cardholder is in possession of credit card. You must set the <strong>bin</strong> field if you set this one.</td>
+         <td>The customer service phone number listed on the back of the credit card as provided by the end-user who initiated the event. This is used to verify that cardholder is in possession of credit card. You must set the <strong>bin</strong> field if you set this one.</td>
       </tr>
       <tr>
          <td colspan="3">
@@ -645,7 +645,7 @@ current when they signed up for the service. The latest version is 1.3.
                </tbody>
             </table>
 
-            <strong>Note:</strong> Anonymous proxies will generally return a <code>proxyScore</code> of 0. Since people in high risk countries most often use proxies in low risk countries, IP addresses located in high risk countries will generally return a <code>proxyScore</code> of 0 as well.
+            <strong>Note:</strong> Anonymous proxies will generally return a <code>proxyScore</code> of 0.
          </td>
          <td>1.0</td>
       </tr>


### PR DESCRIPTION
**minFraud Legacy**
* nest 'Security' under 'HTTP API' heading
* improve copy about reporting transactions
* remove note about "high risk countries" from output table
* clarify source of `binName` and `binPhone` inputs

**Evaluate a Transaction**
* add link to license key management
* copyedit wording for mandatory fields