### PR TITLE
Numerous copyedits to API Documentation

### DIFF
--- a/content/minfraud/api-documentation.mdx
+++ b/content/minfraud/api-documentation.mdx
@@ -77,7 +77,7 @@ service.
 
 ## Versioning
 
-The minFraud Score and minFraud Insights web services use two part versions. Our
+The minFraud Score, minFraud Insights, and minFraud Factors web services use two part versions. Our
 current release is version 2.0. The major version number will remain at 2 for
 the foreseeable future.
 

--- a/content/minfraud/api-documentation.mdx
+++ b/content/minfraud/api-documentation.mdx
@@ -77,9 +77,9 @@ service.
 
 ## Versioning
 
-The minFraud Score, minFraud Insights, and minFraud Factors web services use two part versions. Our
-current release is version 2.0. The major version number will remain at 2 for
-the foreseeable future.
+The minFraud Score, minFraud Insights, and minFraud Factors web services use 
+two part versions. Our current release is version 2.0. The major version number
+will remain at 2 for the foreseeable future.
 
 The minor version will only change if there are breaking changes in the web
 service. A breaking change is one that breaks client code that follows the

--- a/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
@@ -59,7 +59,7 @@ import responseJson from '../_examples/response';
     }}
   >
     Individualized risk of chargeback for the given IP address based on the number of chargebacks and high risk activity sighted on your account
-    and shop ID from this an similar IP networks. This is only available to users [sending chargeback data to MaxMind](/minfraud/report-transactions). 
+    and shop ID from this an similar IP networks. This is only available to users [sending chargeback data to MaxMind](/minfraud/report-a-transaction). 
     If present, this is a value in the range 0.01 to 99.
   </Property>
 

--- a/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
@@ -58,9 +58,9 @@ import responseJson from '../_examples/response';
       'Max': 99,
     }}
   >
-    Individualized risk of chargeback for the given IP address on your account
-    and shop ID. This is only available to users sending chargeback data to
-    MaxMind. If present, this is a value in the range 0.01 to 99.
+    Individualized risk of chargeback for the given IP address based on the number of chargebacks and high risk activity sighted on your account
+    and shop ID from this an similar IP networks. This is only available to users [sending chargeback data to MaxMind](/minfraud/report-transactions). 
+    If present, this is a value in the range 0.01 to 99.
   </Property>
 
   <Property

--- a/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
@@ -58,8 +58,10 @@ import responseJson from '../_examples/response';
       'Max': 99,
     }}
   >
-    Individualized risk of chargeback for the given IP address based on the number of chargebacks and high risk activity sighted on your account
-    and shop ID from this an similar IP networks. This is only available to users [sending chargeback data to MaxMind](/minfraud/report-a-transaction). 
+    Individualized risk of chargeback for the given IP address based on the 
+    number of chargebacks and high risk activity sighted on your account
+    and shop ID from this an similar IP networks. This is only available to 
+    users [sending chargeback data to MaxMind](/minfraud/report-a-transaction). 
     If present, this is a value in the range 0.01 to 99.
   </Property>
 

--- a/content/minfraud/api-documentation/requests.mdx
+++ b/content/minfraud/api-documentation/requests.mdx
@@ -40,52 +40,17 @@ geographically closest to you.
 
 ## Headers
 
-<table>
-  <thead>
-    <tr>
-      <th>Header</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        `Authorization`
-      </td>
-      <td>
-        **Required** – For more details, see
-        [Authorization and Security](#authorization-and-security).
-      </td>
-    </tr>
-    <tr>
-      <td>
-        `Accept`
-      </td>
-      <td>
-        **Optional** – If you do set this header, you must accept any of the
-        following, substituting the appropriate `[SERVICE TYPE]` for either
-        `score`, `factors`, or `insights`:
+The `Authorization` header is always required. See [Authorization and Security](#authorization-and-security) for more details.
 
-        * `application/json`
-        * `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json`
-        * `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json; charset=UTF-8; version=2.0`
+The `Accept` header for a request is entirely optional. If you do include one, you must accept one of the following, substituting the `[SERVICE-TYPE]` with either `score`, `insights`, or `factors` as appropriate:
 
+* `application/json`
+* `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json`
+* application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json; charset=UTF-8; version=2.0
+ 
+ A request for any other MIME type will result in a `415 Unsupported Media Type` error.
 
-        A request for any other MIME type will result in a `415 Unsupported Media Type` error.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        `Accept-Charset`
-      </td>
-      <td>
-        **Optional** – If you do set this header, you must accept the `UTF-8`
-        character set. If you don't you will receive a `406 Not Acceptable`
-        response, because this data is only available in `UTF-8`.
-      </td>
-    </tr>
-  </tbody>
-</table>
+If you set the `Accept-Charset` header in your client code, you must accept the `UTF-8` character set. If you don't you will receive a `406 Not Acceptable` response.
 
 ## Bodies
 minFraud Score, Factors and Insights share the same request body format. Below

--- a/content/minfraud/api-documentation/requests.mdx
+++ b/content/minfraud/api-documentation/requests.mdx
@@ -46,7 +46,7 @@ The `Accept` header for a request is entirely optional. If you do include one, y
 
 * `application/json`
 * `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json`
-* application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json; charset=UTF-8; version=2.0
+* `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json; charset=UTF-8; version=2.0`
  
  A request for any other MIME type will result in a `415 Unsupported Media Type` error.
 

--- a/content/minfraud/api-documentation/requests.mdx
+++ b/content/minfraud/api-documentation/requests.mdx
@@ -40,17 +40,23 @@ geographically closest to you.
 
 ## Headers
 
-The `Authorization` header is always required. See [Authorization and Security](#authorization-and-security) for more details.
+The `Authorization` header is always required. See 
+[Authorization and Security](#authorization-and-security) for more details.
 
-The `Accept` header for a request is entirely optional. If you do include one, you must accept one of the following, substituting the `[SERVICE-TYPE]` with either `score`, `insights`, or `factors` as appropriate:
+The `Accept` header for a request is entirely optional. If you do include one,
+you must accept one of the following, substituting the `[SERVICE-TYPE]` with 
+either `score`, `insights`, or `factors` as appropriate:
 
 * `application/json`
 * `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json`
 * `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json; charset=UTF-8; version=2.0`
  
- A request for any other MIME type will result in a `415 Unsupported Media Type` error.
+ A request for any other MIME type will result in a 
+ `415 Unsupported Media Type` error.
 
-If you set the `Accept-Charset` header in your client code, you must accept the `UTF-8` character set. If you don't you will receive a `406 Not Acceptable` response.
+If you set the `Accept-Charset` header in your client code, you must accept the 
+`UTF-8` character set. If you don't you will receive a `406 Not Acceptable` 
+response.
 
 ## Bodies
 minFraud Score, Factors and Insights share the same request body format. Below

--- a/content/minfraud/api-documentation/responses.mdx
+++ b/content/minfraud/api-documentation/responses.mdx
@@ -45,16 +45,23 @@ The `Content-Type` for a successful response varies based on the service as outl
   </tbody>
 </table>
 
-Errors may be returned with the `Content-Type` set to `application/vnd.maxmind.com-error+json; charset=UTF-8; version=2.0`.
-If this is the case, then the body of the response contains a JSON
-document with two keys, code and error. See the [Errors](/minfraud/api-documentation/responses/#errors)
-section for more details.
+Errors may be returned with the `Content-Type` set to 
+`application/vnd.maxmind.com-error+json; charset=UTF-8; version=2.0`.
+If this is the case, then the body of the response contains a JSON document 
+with two keys, code and error. See the 
+[Errors](/minfraud/api-documentation/responses/#errors) section for more 
+details.
 
 A `Content-Length` header will be provided.
 
 ## Bodies
 
-Each service returns data as a JSON document. The document that is returned always consists of an object (aka map or hash). Below are full examples of the JSON body document for the minFraud Score, minFraud Insights, and minFraud Factors services, and a full example of the JSON body document for an error. For detailed explanations of each property within the response body, please refer to the [object reference](#object-reference) section below.
+Each service returns data as a JSON document. The document that is returned 
+always consists of an object (aka map or hash). Below are full examples of the 
+JSON body document for the minFraud Score, minFraud Insights, and minFraud 
+Factors services, and a full example of the JSON body document for an error. 
+For detailed explanations of each property within the response body, please 
+refer to the [object reference](#object-reference) section below.
 
 ### Score Body
 
@@ -147,7 +154,7 @@ to handle any valid HTTP `4xx` or `5xx` status code.
       <td>402 Payment Required</td>
       <td>
         The license key you have provided does not have sufficient funds to use
-        this service. Please [purchase more service credits](https://www.maxmind.com/en/solutions/minfraud-services#buy-now.).
+        this service. Please [purchase more service credits](https://www.maxmind.com/en/solutions/minfraud-services#buy-now).
       </td>
     </tr>
     <tr>

--- a/content/minfraud/api-documentation/responses.mdx
+++ b/content/minfraud/api-documentation/responses.mdx
@@ -8,45 +8,53 @@ import * as Schemas from './_schemas/';
 
 ## Headers
 
+The `Content-Type` for a successful response varies based on the service as outlined below:
+
 <table>
   <thead>
     <tr>
-      <th>Header</th>
-      <th>Notes</th>
+      <th>Service</th>
+      <th>Content-Type</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>
-        `Content-Type`
+        Score
       </td>
       <td>
-        The `Content-Type` header for a successful response varies based on the
-        service as outlined above.
-
-        Errors may be returned with the `Content-Type` set to
-        `application/vnd.maxmind.com-error+json; charset=UTF-8; version=2.0`.
-        If this is the case, then the body of the response contains a JSON
-        document with two keys, code and error. See the [Errors](/minfraud/api-documentation/responses/#errors)
-        section for more details.
+        `application/vnd.maxmind.com-minfraud-score+json; charset=UTF-8; version=2.0`
       </td>
     </tr>
     <tr>
       <td>
-        `Content-Length`
+        Insights
       </td>
       <td>
-        The response will always include a `Content-Length` header as well.
+        `application/vnd.maxmind.com-minfraud-insights+json; charset=UTF-8; version=2.0`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Factors
+      </td>
+      <td>
+        `application/vnd.maxmind.com-minfraud-factors+json; charset=UTF-8; version=2.0`
       </td>
     </tr>
   </tbody>
 </table>
 
+Errors may be returned with the `Content-Type` set to `application/vnd.maxmind.com-error+json; charset=UTF-8; version=2.0`.
+If this is the case, then the body of the response contains a JSON
+document with two keys, code and error. See the [Errors](/minfraud/api-documentation/responses/#errors)
+section for more details.
+
+A `Content-Length` header will be provided.
+
 ## Bodies
 
-Each service returns data as a JSON document. The document that is returned
-always consists of an object (aka map or hash). Below are the schema definitions
-that describe each service's response body.
+Each service returns data as a JSON document. The document that is returned always consists of an object (aka map or hash). Below are full examples of the JSON body document for the minFraud Score, minFraud Insights, and minFraud Factors services, and a full example of the JSON body document for an error. For detailed explanations of each property within the response body, please refer to the [object reference](#object-reference) section below.
 
 ### Score Body
 
@@ -139,7 +147,7 @@ to handle any valid HTTP `4xx` or `5xx` status code.
       <td>402 Payment Required</td>
       <td>
         The license key you have provided does not have sufficient funds to use
-        this service. Please [purchase more service credits](https://www.maxmind.com/en/purchase-minfraud-services).
+        this service. Please [purchase more service credits](https://www.maxmind.com/en/solutions/minfraud-services#buy-now.).
       </td>
     </tr>
     <tr>

--- a/content/minfraud/report-a-transaction.mdx
+++ b/content/minfraud/report-a-transaction.mdx
@@ -19,7 +19,7 @@ official client libraries.
 MaxMind offers and highly recommends using official client libraries to access
 the Report Transation API. If you cannot or do not wish to use our client
 libraries, please review our
-[minFraud Report Transaction API Documentation)](#api-documentation) for details
+[minFraud Report Transaction API Documentation](#api-documentation) for details
 on our JSON API.
 
 ### 1. Install the minFraud client library

--- a/content/minfraud/working-with-transaction-dispositions.mdx
+++ b/content/minfraud/working-with-transaction-dispositions.mdx
@@ -59,7 +59,9 @@ you must accept one of the following:
 * `application/vnd.maxmind.com-disposition-updates+json`
 * `application/vnd.maxmind.com-disposition-updates+json; charset=UTF-8; version=1.0`
 
-If you set the `Accept-Charset` header in your client code, you must accept the `UTF-8` character set. If you don't you will receive a `406 Not Acceptable` response.
+If you set the `Accept-Charset` header in your client code, you must accept the 
+`UTF-8` character set. If you don't you will receive a `406 Not Acceptable` 
+response.
 
 ### Command Line Example Using curl
 

--- a/content/minfraud/working-with-transaction-dispositions.mdx
+++ b/content/minfraud/working-with-transaction-dispositions.mdx
@@ -59,9 +59,7 @@ you must accept one of the following:
 * `application/vnd.maxmind.com-disposition-updates+json`
 * `application/vnd.maxmind.com-disposition-updates+json; charset=UTF-8; version=1.0`
 
-If you set the `Accept-Charset` header in your client code, you must accpe the
-`UTF-8` character set;  If you do not you will receive a `406 Not Acceptable`
-response.
+If you set the `Accept-Charset` header in your client code, you must accept the `UTF-8` character set. If you don't you will receive a `406 Not Acceptable` response.
 
 ### Command Line Example Using curl
 


### PR DESCRIPTION
Several medium-priority copyedits to API Documentation (and two minor copyedit fixes I noticed when comparing to other pages for consistency in our copy).

* convert the header sections in API Requests and API Responses from tables
* fix spelling error on Working with Transaction Dispositions > Request headers
* update API Documentation > Versioning copy to include factors
* update chargeback subscore description
* update link to purchase service credit
* remove trailing parenthesis in report transaction API link in Report a transaction > Implementation
* add content-types to API Reponses header documentation
* rework copy of API Requests > Bodies for consistency