### PR TITLE
Critical and medium priority fixes from support UAT

### DIFF
--- a/content/minfraud/api-documentation.mdx
+++ b/content/minfraud/api-documentation.mdx
@@ -86,8 +86,8 @@ service. A breaking change is one that breaks client code that follows the
 documentation on this page. Breaking changes include changing the type of an
 existing field, deleting a field entirely, or changing URIs.
 
-All changes to the web services will be documented in the minFraud release
-notes, whether or not the version number is changed.
+All changes to the web services will be documented in the
+[minFraud release notes](/minfraud/release-notes), whether or not the version number is changed.
 
 The following changes are not considered to be breaking changes and will not be
 accompanied by a version number change:

--- a/content/minfraud/api-documentation/_schemas/Response.mdx
+++ b/content/minfraud/api-documentation/_schemas/Response.mdx
@@ -6,6 +6,8 @@ import responseJson from '../_examples/response';
   name="Response"
   services="*"
 >
+The following is an example of a complete minFraud Factors response, including all available outputs. In practice, fewer outputs may be returned based on the minFraud service you query and the inputs provided.
+
   <Property
     name="id"
     tags={{

--- a/content/minfraud/index.mdx
+++ b/content/minfraud/index.mdx
@@ -14,7 +14,7 @@ import {
   FaRocket,
 } from 'react-icons/fa';
 
-minFraud is our transaction risk API, consisting of the the minFraud Score,
+minFraud is our transaction risk API, consisting of the minFraud Score,
 Insights and Factors services.
 
 <Alert type="info">
@@ -45,7 +45,7 @@ Insights and Factors services.
       description="Capture more data and catch more fraud using our JavaScript device tracking library."
       heading="Integrate Device Tracking"
       icon={FaShoePrints}
-      to="/minfraud/evaluate-a-transaction"
+      to="/minfraud/track-devices"
     />
   </LinkGroup>
 
@@ -67,8 +67,8 @@ Insights and Factors services.
     <LinkGroupCard
       description="Capture more data and catch more fraud using our JavaScript device tracking library."
       heading="FAQ"
-      href="https://support.maxmind.com/minfraud-faq/"
       icon={FaQuestionCircle}
+      to="https://support.maxmind.com/minfraud-faq/"
     />
   </LinkGroup>
 </LinkGroupContainer>

--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -28,10 +28,13 @@ service, you must have a valid
 We encourage you to use one our minFraud client APIs if possible. APIs are
 available in the following languages:
 
+{/* <!--lint disable maximum-line-length --> */}
+| Language/Platform | Documentation                                                                                 | Package Repository                                                                                                    | Version Control                                    |
 | ----------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | Java              | [Documentation](https://github.com/maxmind/ccfd-api-java/blob/master/README.md)               | [Maven Central Repository](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22minfraud-api%22)                        | [GitHub](https://github.com/maxmind/ccfd-api-java) |
 | Perl              | [Documentation](https://metacpan.org/pod/Business%3A%3AMaxMind%3A%3ACreditCardFraudDetection) | [MetaCPAN](https://metacpan.org/pod/Business%3A%3AMaxMind%3A%3ACreditCardFraudDetection)                              | [GitHub](https://github.com/maxmind/ccfd-api-perl) |
 | PHP               | [Documentation](https://github.com/maxmind/ccfd-api-php/blob/master/README.md)                | [Composer](https://packagist.org/packages/minfraud/http) / [Source](https://github.com/maxmind/ccfd-api-php/releases) | [GitHub](https://github.com/maxmind/ccfd-api-php)  |
+{/* <!--lint enable maximum-line-length --> */}
 
 The client APIs take care of formatting requests and parsing the response for
 you.

--- a/content/minfraud/report-a-transaction.mdx
+++ b/content/minfraud/report-a-transaction.mdx
@@ -16,7 +16,7 @@ official client libraries.
 
 ## Implementation
 
-MaxMind offers and highly recommends using official client libraries to access
+MaxMind offers and highly recommends using [official client libraries](evaluate-a-transaction/#links-to-maxmind-client-apis) to access
 the Report Transation API. If you cannot or do not wish to use our client
 libraries, please review our
 [minFraud Report Transaction API Documentation](#api-documentation) for details
@@ -267,8 +267,11 @@ your
 [MaxMind account ID](https://www.maxmind.com/en/accounts/current/license-key).
 The password is your
 [MaxMind license key](https://www.maxmind.com/en/accounts/current/license-key).
-You must be approved for a trial or purchase credit for use with our web
-services in order to receive an account ID and license key.
+
+<Alert type="warning">
+  You must be approved for a trial or purchase credit for use with our web
+  services in order to receive an account ID and license key.
+</Alert>
 
 We use
 [basic HTTP authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
@@ -278,6 +281,10 @@ service via HTTP, you will receive a `403 Forbidden` HTTP response.
 
 We require TLS 1.2 or greater for all requests to our servers to keep your data
 secure.
+
+### Request Headers
+
+The `Content-Type` header should always be `application/json`.
 
 ### Request Body
 
@@ -294,10 +301,6 @@ following keys (key names are case-sensitive):
 | **minfraud_id**     | string (36) | *Optional.* A UUID that identifies a minFraud Score, minFraud Insights, or minFraud Factors request. This ID is returned at `/id` in the response. This field is not required, but you are encouraged to provide it if the request was made to one of these services.           |
 | **notes**           | string      | *Optional.* Your notes on the fraud tag associated with the transaction. We manually review many reported transactions to improve our scoring for you so any additional details to help us understand context are helpful.                                                      |
 | **transaction_id**  | string      | *Optional.* The transaction ID you originally passed to minFraud. This field is not required, but you are encouraged to provide it or the transaction’s `maxmind_id` or `minfraud_id`.                                                                                          |
-
-### Request Headers
-
-The `Content-Type` header should always be `application/json`.
 
 ### Response
 

--- a/content/minfraud/track-devices.mdx
+++ b/content/minfraud/track-devices.mdx
@@ -7,7 +7,7 @@ The Device Tracking Add-On for the minFraud services identifies devices as they
 move across networks and enhances the ability of the minFraud services to
 detect fraud. If a fraudster changes proxies while they are browsing your
 website or between visits to your website, you may observe an increased
-riskScore in the minFraud output associated with their transactions.
+risk score in the minFraud output associated with their transactions.
 
 We may increase the risk score if we detect order velocity on the device. We
 also return a [device ID](/minfraud/api-documentation/#schema--response--device)

--- a/content/minfraud/working-with-transaction-dispositions.mdx
+++ b/content/minfraud/working-with-transaction-dispositions.mdx
@@ -6,15 +6,17 @@ title: Working with Transaction Dispositions
 With minFraud Interactive, customers can create Custom Rules that are used to
 assign a disposition to every transaction received in a minFraud request.
 Custom Rules can set a transaction’s disposition to `accept`, `reject`, or
-`manual_review`.
+`manual_review`. For more information on Custom Rules and Dispositions, see the documentation in our [Support Center](https://support.maxmind.com/minfraud-interactive/).
 
-After transactions are received, customers can use the minFraud Interactive
-interface to review all transactions dispositioned as `manual_review`.
+After transactions are received, customers can use the [minFraud Interactive
+interface](https://support.maxmind.com/minfraud-interactive/) to review all transactions dispositioned as `manual_review`.
 Transactions can then either be `accept`ed or `reject`ed, and/or have a note
 added. In order for these manual updates made in minFraud Interactive to be
 useful, they need to find their way back into customers’ systems. The
 Dispositions API allows customers to get a list of the manual updates and notes
 made to their transactions.
+
+**You only need to implement the Dispositions API if you (1) use the minFraud Interactive interface to make manual changes to dispositions, and (2) require those changes to propagate to your own system.**
 
 ## Making a disposition request
 
@@ -40,10 +42,13 @@ The HTTP Authorization header is required for authorization. The username is
 your [MaxMind account
 ID](https://www.maxmind.com/en/accounts/current/license-key). The password is
 your [MaxMind license
-key](https://www.maxmind.com/en/accounts/current/license-key). You must be
-approved for a trial or purchase credit for use with our
-web services in order to receive an account ID and license key. The
+key](https://www.maxmind.com/en/accounts/current/license-key).  The
 authorization realm is `minfraud`.
+
+<Alert type="warning">
+  You must be approved for a trial or purchase credit for use with our web
+  services in order to receive an account ID and license key.
+</Alert>
 
 We use basic HTTP authentication. The APIs which require authentication are
 only available via HTTPS. The credentials are never transmitted unencrypted. If
@@ -203,9 +208,9 @@ to handle any valid HTTP 4xx or 5xx status code.
 | UPDATES_AFTER_REQUIRED | 400 Bad Request            | You have not supplied the `updates_after`  URI parameter.                                                             |
 | TIMESTAMP_INVALID      | 400 Bad Request            | The `updates_after` field must be in RFC 3339 format.                                                                 |
 | PARAMETER_UNKNOWN      | 400 Bad Request            | You have supplied one or more parameters which are not used by this endpoint.                                         |
-| AUTHORIZATION_INVALID  | 401 Unauthorized           | Your account ID or license key could not be authenticated.                                                            |
-| LICENSE_KEY_REQUIRED   | 401 Unauthorized           | An account ID and license key are required to use this service.                                                       |
-| ACCOUNT_ID_REQUIRED    | 401 Unauthorized           | An account ID and license key are required to use this service.                                                       |
+| AUTHORIZATION_INVALID  | 401 Unauthorized           | You have supplied an invalid [MaxMind account ID and/or license key](https://www.maxmind.com/en/my_license_key) in the [Authorization](#authorization-and-security) header.                                                            |
+| LICENSE_KEY_REQUIRED   | 401 Unauthorized           | You have not supplied a [MaxMind license key](https://www.maxmind.com/en/my_license_key) in the [Authorization](#authorization-and-security) header.                                                       |
+| ACCOUNT_ID_REQUIRED    | 401 Unauthorized           | You have not supplied a [MaxMind account ID](https://www.maxmind.com/en/my_license_key) in the [Authorization](#authorization-and-security) header.                                                       |
 | PERMISSION_REQUIRED    | 403 Forbidden              | You do not have permission to use the service. Please contact support@maxmind.com for more information.               |
 | (none)                 | 406 Not Acceptable         | Your request included an `Accept-Charset` header that is not supported. `UTF-8` is the only acceptable character set. |
 | (none)                 | 415 Unsupported Media Type | Your request included an `Accept` header that is not supported. The web service cannot return content of that type.   |


### PR DESCRIPTION
- riskScore --> risk score
- standardize language and linking for unsuccessful response documentation
- standardize alert box warning that customer must be approved across all pages
- add/fix links to the support center
- clarify response example includes outputs for all services
- clarify conditions under which a customer must implement dispositions API
- re-order sections on report a transaction page
- link to client libraries list where mentioned on report a transaction page
- link to release notes where mentioned in versioning