### PR TITLE
Add minFraud alerts release note

### DIFF
--- a/content/minfraud/release-notes.mdx
+++ b/content/minfraud/release-notes.mdx
@@ -24,6 +24,13 @@ See our developer documentation for the [updated codes and
 warnings](/minfraud/api-documentation/responses/#schema--response--warnings).
 </ReleaseNote>
 
+<ReleaseNote date="2021-05-13" title="Updates to minFraud Alerts">
+We recently made some updates to minFraud alerts, which notifies minFraud users
+about previously low-risk transactions that are now high-risk due to updated
+information. Learn more [on our
+blog](https://blog.maxmind.com/2021/05/12/what-are-minfraud-alerts-and-what-do-i-do-with-them/).
+</ReleaseNote>
+
 <ReleaseNote date="2021-02-22" title="Normalize Emails Before Hashing for Improved minFraud Scoring">
 The client APIs for minFraud Score, Insights, and Factors now normalize emails
 prior to hashing them for improved risk scoring. Email normalization ensures


### PR DESCRIPTION
Add a release note to minFraud that was missed in the migration.