### PR TITLE
Fix typo, add mention to root database documentation page

### DIFF
--- a/content/geoip/docs/databases.mdx
+++ b/content/geoip/docs/databases.mdx
@@ -150,3 +150,9 @@ import {
 | Network Protocol Analyzer      | Wireshark               | [How To Use GeoIP With Wireshark](https://wiki.wireshark.org/HowToUseGeoIP)                                             |
 | Search                         | Elasticsearch           | [GeoIP processor](https://www.elastic.co/guide/en/elasticsearch/reference/current/geoip-processor.html#geoip-processor) |
 
+## Command Line (mmdbinspect)
+
+You can use the [mmdbinspect tool](https://github.com/maxmind/mmdbinspect) (in
+beta), a command line interface built with Go, to look up one or more IPs from
+one or more MMDB databases and receive output in a parsable JSON format.
+

--- a/content/geoip/geolocate-an-ip/databases.mdx
+++ b/content/geoip/geolocate-an-ip/databases.mdx
@@ -228,7 +228,7 @@ puts record.country.iso_code
 | Scala                | maxmind-geoip2-scala    |                                                                       | [README](https://github.com/Sanoma-CDA/maxmind-geoip2-scala/blob/master/README.md) | [GitHub](https://github.com/Sanoma-CDA/maxmind-geoip2-scala) |
 | Swift (C extension)  | MMDB-Swift              | [MMDB-Swift](https://cocoapods.org/pods/MMDB-Swift)                   | [CocoaPods](hhttps://cocoapods.org/pods/MMDB-Swift)                                | [GitHub](https://github.com/lexrus/MMDB-Swift)               |
 
-## Comand Line (mmdbinspect)
+## Command Line (mmdbinspect)
 
 You can use the [mmdbinspect tool](https://github.com/maxmind/mmdbinspect) (in
 beta), a command line interface built with Go, to look up one or more IPs from


### PR DESCRIPTION
Sorry, caught a typo, and it was requested to add mention to one additional page.
- Fix typo "Comand Line" --> "Command Line"
- Add mention to root database page