### PR TITLE
Change language around Connection Type and Enterprise data inclusion in Precision Insights for clarity

### DIFF
--- a/content/geoip/_geoip-overview.mdx
+++ b/content/geoip/_geoip-overview.mdx
@@ -74,7 +74,7 @@ Center](https://support.maxmind.com/geoip-faq/specifications-and-implementation/
         [Docs <GoToIcon />](/geoip/docs/databases/connection-type/#csv-databases)
       </td>
       <td>
-        Included in the GeoIP2 Precision Insights web service.
+        Comparable data included in the GeoIP2 Precision Insights web service.
       </td>
     </tr>
     <tr>
@@ -86,7 +86,7 @@ Center](https://support.maxmind.com/geoip-faq/specifications-and-implementation/
         [Docs <GoToIcon />](/geoip/docs/databases/enterprise/#csv-databases)
       </td>
       <td>
-        Included in the GeoIP2 Precision Insights web service.
+        Comparable data included in the GeoIP2 Precision Insights web service.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Clarify the description in the GeoIP Product Overview table of Connection Type and Enterprise data. Previously this read "Included in GeoIP2 Precision Insights," now it reads "Comparable data ...".