### PR TITLE
Fix TypeScript and linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-icons": "^4.1.0",
-    "react-markdown": "^6.0.1",
     "remark-external-links": "^8.0.0",
     "remark-frontmatter": "^3.0.0",
     "sass-loader": "^12.1.0",

--- a/src/components/Mdx/Pre/Pre.tsx
+++ b/src/components/Mdx/Pre/Pre.tsx
@@ -65,12 +65,15 @@ const Pre: React.FC<React.HTMLProps<HTMLDivElement> & IPre> = (props) => {
 
   const handleCopyClick = (): void => {
     setIsCopying(true);
-    navigator.clipboard.writeText(child.props.children.trim())
-      .then(() => {
-        setTimeout(() => {
-          setIsCopying(false);
-        }, 3000);
-      });
+
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(child.props.children.trim())
+        .then(() => {
+          setTimeout(() => {
+            setIsCopying(false);
+          }, 3000);
+        });
+    }
   };
 
   /* ---------- */
@@ -154,7 +157,7 @@ const Pre: React.FC<React.HTMLProps<HTMLDivElement> & IPre> = (props) => {
         <div
           className={styles['toolbar__buttons']}
         >
-          {navigator.clipboard && (
+          {Object.prototype.hasOwnProperty.call(navigator, 'clipboard') && (
             <Button
               className={classNames(
                 styles.copyBtn,

--- a/src/gatsby/gatsby-node/createPages.ts
+++ b/src/gatsby/gatsby-node/createPages.ts
@@ -1,6 +1,5 @@
 import { CreatePagesArgs, GatsbyNode } from 'gatsby';
 
-import createApiSpecPages from './pages/createApiSpecPages';
 import createMdxPages from './pages/createMdxPages';
 
 export const createPages: GatsbyNode['createPages'] = async (
@@ -8,6 +7,5 @@ export const createPages: GatsbyNode['createPages'] = async (
 ) => {
   await Promise.all([
     createMdxPages(props),
-    createApiSpecPages(props),
   ]);
 };

--- a/src/templates/ApiReference/Schema/Content/Content.tsx
+++ b/src/templates/ApiReference/Schema/Content/Content.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FaAngleDoubleDown } from 'react-icons/fa';
 
-import { renderMarkdownElement } from '../utils';
+import { renderMarkdown } from '../../../../utils/markdown';
 import Properties from './Properties';
 
 import * as styles from './Content.module.scss';
@@ -36,7 +36,7 @@ const Content: React.FC<IContent> = (
             <div
               className={styles.description}
             >
-              {renderMarkdownElement(
+              {renderMarkdown(
                 props.schema.description as unknown as string
               )}
             </div>

--- a/src/templates/ApiReference/Schema/Content/Properties.tsx
+++ b/src/templates/ApiReference/Schema/Content/Properties.tsx
@@ -4,8 +4,9 @@ import { OpenAPIV3 } from 'openapi-types';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { renderMarkdown } from '../../../../utils/markdown';
 import Type from '../Type';
-import { getRefAnchorLink, renderMarkdownElement } from '../utils';
+import { getRefAnchorLink } from '../utils';
 import parseSchema from './parseSchema';
 
 import * as styles from './Properties.module.scss';
@@ -78,7 +79,7 @@ const Row: React.FC<IRow> = (props) => {
         <div
           className={styles.description}
         >
-          {renderMarkdownElement(props.description)}
+          {renderMarkdown(props.description)}
         </div>
       )}
     </div>

--- a/src/templates/ApiReference/Schema/utils.tsx
+++ b/src/templates/ApiReference/Schema/utils.tsx
@@ -1,11 +1,4 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
-
-import { a } from '../../../components/Mdx';
-
-const components = {
-  link: a,
-};
 
 const NameRegex = new RegExp('\\.', 'g');
 
@@ -19,15 +12,5 @@ export const getRefAnchorLink = (ref: string): React.ReactElement => {
     >
       {link}
     </a>
-  );
-};
-
-export const renderMarkdownElement = (content: string): React.ReactElement => {
-  return (
-    <ReactMarkdown
-      components={components}
-    >
-      {content}
-    </ReactMarkdown>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13568,7 +13568,7 @@ mdast-util-to-hast@9.1.0:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
-mdast-util-to-hast@^10.0.0, mdast-util-to-hast@^10.1.1, mdast-util-to-hast@^10.2.0:
+mdast-util-to-hast@^10.0.0, mdast-util-to-hast@^10.1.1:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz#61875526a017d8857b71abc9333942700b2d3604"
   integrity sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==
@@ -16929,7 +16929,7 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
+"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -16938,25 +16938,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-markdown@^6.0.1:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-6.0.3.tgz#625ec767fa321d91801129387e7d31ee0cb99254"
-  integrity sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==
-  dependencies:
-    "@types/hast" "^2.0.0"
-    "@types/unist" "^2.0.3"
-    comma-separated-tokens "^1.0.0"
-    prop-types "^15.7.2"
-    property-information "^5.3.0"
-    react-is "^17.0.0"
-    remark-parse "^9.0.0"
-    remark-rehype "^8.0.0"
-    space-separated-tokens "^1.1.0"
-    style-to-object "^0.3.0"
-    unified "^9.0.0"
-    unist-util-visit "^2.0.0"
-    vfile "^4.0.0"
 
 react-refresh@^0.9.0:
   version "0.9.0"
@@ -18146,13 +18127,6 @@ remark-preset-lint-recommended@^5.0.0:
     remark-lint-no-unused-definitions "^2.0.0"
     remark-lint-ordered-list-marker-style "^2.0.0"
 
-remark-rehype@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-8.1.0.tgz#610509a043484c1e697437fa5eb3fd992617c945"
-  integrity sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==
-  dependencies:
-    mdast-util-to-hast "^10.2.0"
-
 remark-retext@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/remark-retext/-/remark-retext-3.1.3.tgz#77173b1d9d13dab15ce5b38d996195fea522ee7f"
@@ -19333,7 +19307,7 @@ sourcemap-codec@^1.4.4:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-space-separated-tokens@^1.0.0, space-separated-tokens@^1.1.0:
+space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
@@ -21080,7 +21054,7 @@ unified@^8.4.2:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^9.0.0, unified@^9.1.0, unified@^9.2.0:
+unified@^9.1.0, unified@^9.2.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
* Fixes eslint `no-compat/no-compat` errors relating to using `navigator.clipboard()` 
* Removes `react-markdown` implementation that is causing a TypeScript error
* Disabled generation of OpenAPI Spec generated api reference pages.

I'm keeping the OpenAPI spec template code around for now. Eventually, we should probably move that into it's own branch for historical purposes, and remove it from the rest of the codebase.