### PR TITLE
Add support for 8 digit iins and last_digits

### DIFF
--- a/content/minfraud/api-documentation/_examples/request.ts
+++ b/content/minfraud/api-documentation/_examples/request.ts
@@ -23,7 +23,7 @@ export default {
     bank_phone_number: '800-342-1232',
     cvv_result: 'N',
     issuer_id_number: '323132',
-    last_4_digits: '7643',
+    last_digits: '7643',
     token: 'OQRST14PLQ98323',
     was_3d_secure_successful: true,
   },

--- a/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
@@ -12,20 +12,22 @@ import requestJson from '../_examples/request';
   <Property
     name="issuer_id_number"
     tags={{
-      'Max Length': 6,
+      'Max Length': 8,
     }}
   >
-    The issuer ID number for the credit card. This is the first six digits of
-    the credit card number. It identifies the issuing bank.
+    The issuer ID number for the credit card. This is the first six or eight
+    digits of the credit card number. It identifies the issuing bank.
   </Property>
 
   <Property
-    name="last_4_digits"
+    name="last_digits"
     tags={{
       'Max Length': 4,
     }}
   >
-    The last four digits of the credit card number.
+    The last digits of the credit card number. `last_digits` should be two
+    digits if the issuer ID number sent is eight digits; `last_digits`
+    should be four digits otherwise.
   </Property>
 
   <Property

--- a/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
@@ -16,7 +16,8 @@ import requestJson from '../_examples/request';
     }}
   >
     The issuer ID number for the credit card. This is the first six or eight
-    digits of the credit card number. It identifies the issuing bank.
+    digits of the credit card number. It identifies the issuing bank. If you do
+    not know whether the IIN is six or eight digits long, send us six digits.
   </Property>
 
   <Property
@@ -25,9 +26,12 @@ import requestJson from '../_examples/request';
       'Max Length': 4,
     }}
   >
-    The last digits of the credit card number. `last_digits` should be two
-    digits if the issuer ID number sent is eight digits; `last_digits`
-    should be four digits otherwise.
+    The last digits of the credit card number. If you send six digits for the
+    [`issuer_id_number`](#schema--request--credit-card__issuer_id_number), you
+    should send the last four digits for `last_digits`. If you send eight digits
+    for `issuer_id_number`, you should send the last two digits for
+    `last_digits`. If you don't know how many digits you send for
+    `issuer_id_number`, you should send the last two digits for `last_digits`.
   </Property>
 
   <Property

--- a/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
@@ -26,12 +26,12 @@ import requestJson from '../_examples/request';
       'Max Length': 4,
     }}
   >
-    The last digits of the credit card number. If you send six digits for the
-    [`issuer_id_number`](#schema--request--credit-card__issuer_id_number), you
-    should send the last four digits for `last_digits`. If you send eight digits
-    for `issuer_id_number`, you should send the last two digits for
-    `last_digits`. If you don't know how many digits you send for
-    `issuer_id_number`, you should send the last two digits for `last_digits`.
+    The last digits of the credit card number. In most cases, you should send
+    the last four digits for `last_digits`. If you send an
+    [`issuer_id_number`](#schema--request--credit-card__issuer_id_number)
+    that contains an eight digit IIN, and if the credit card brand is not one
+    of the following, you should send the last two digits for `last_digits`:
+    `Discover`, `JCB`, `Mastercard`, `UnionPay`, `Visa`.
   </Property>
 
   <Property

--- a/content/minfraud/evaluate-a-transaction.mdx
+++ b/content/minfraud/evaluate-a-transaction.mdx
@@ -929,7 +929,7 @@ $request = $mf->withDevice([
     'decline_code'          => 'invalid number',
 ])->withCreditCard([
     'issuer_id_number'        => '411111',
-    'last_4_digits'           => '1234',
+    'last_digits'             => '1234',
     'bank_name'               => 'Test Bank',
     'bank_phone_country_code' => '1',
     'bank_phone_number'       => '555-555-5555',
@@ -1043,7 +1043,7 @@ foreach ($scoreResponse->warnings as $warning) {
          'bank_phone_country_code': '1',
          'avs_result': 'Y',
          'bank_phone_number': '555-555-5555',
-         'last_4_digits': '1234',
+         'last_digits': '1234',
          'cvv_result': 'N',
          'bank_name': 'Test Bank',
          'issuer_id_number': '411111'
@@ -1159,7 +1159,7 @@ assessment = Minfraud::Assessments.new(
   },
   credit_card: {
     issuer_id_number:        '411111',
-    last_4_digits:           '1234',
+    last_digits:             '1234',
     bank_name:               'Test Bank',
     bank_phone_country_code: '1',
     bank_phone_number:       '555-555-5555',

--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -212,7 +212,7 @@ longer than the longest valid representation of an IPv6 address.
       <tr>
          <td>bin</td>
          <td>string (255)</td>
-         <td>The credit card BIN number. This is the first 6 digits of the credit card number. It identifies the issuing bank.</td>
+         <td>The credit card BIN number. This is the first 6 or 8 digits of the credit card number. It identifies the issuing bank.</td>
       </tr>
       <tr>
          <td>binName</td>

--- a/content/minfraud/whats-new-in-minfraud-score-and-minfraud-insights.mdx
+++ b/content/minfraud/whats-new-in-minfraud-score-and-minfraud-insights.mdx
@@ -74,7 +74,7 @@ for a complete description.
   * `decline_code`
 
 * `credit_card`
-  * `last_4_digits`
+  * `last_digits`
 
 * `order`
   * `affiliate_id`


### PR DESCRIPTION
MinFraud now supports 8 digit iins and changed the name of the
last_4_digits parameter to last_digits. This updates the docs,
examples, etc to accommodate this new MinFraud behavior.