### PR TITLE
Update GitHub actions to use major version

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -83,7 +83,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -108,7 +108,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -139,7 +139,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -176,7 +176,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -221,7 +221,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,7 +19,7 @@ jobs:
       node-modules: node-modules-${{ steps.node-modules.outputs.hash }}-v1
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - id: build
@@ -37,7 +37,7 @@ jobs:
       is-cached-build: ${{ steps.cached-build.outputs.cache-hit }}
 
     steps:
-      - name: Checkout repo
+      - name: Check Out repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - id: build
         run: echo "::set-output name=hash::${{ hashFiles('bin/**', 'content/**', 'firebase/**', 'functions/src/**', 'src/**', 'static/**', '**/package.json', '**/yarn.lock') }}"
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -219,7 +219,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get cached dependencies
         id: cache-node-modules
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -59,7 +59,7 @@ jobs:
 
       - name: Get cached build
         id: cached-build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -88,7 +88,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -113,7 +113,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -144,7 +144,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -181,7 +181,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -197,7 +197,7 @@ jobs:
           export_default_credentials: true
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -226,7 +226,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,7 +19,7 @@ jobs:
       node-modules: node-modules-${{ steps.node-modules.outputs.hash }}-v1
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - id: build
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -134,7 +134,7 @@ jobs:
       hosting-url: ${{ steps.deploy-preview-channel.outputs.details_url }}
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Check Out Repo
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -137,7 +137,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -191,7 +191,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -232,7 +232,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         id: cache-node-modules
         with:
           path: |
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get cached build
         id: cached-build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -65,7 +65,7 @@ jobs:
           key: ${{ needs.cache-keys.outputs.build }}
 
       - name: Get .cache cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             .cache
@@ -91,7 +91,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -115,7 +115,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -142,7 +142,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -196,7 +196,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached build
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             functions/lib
@@ -213,7 +213,7 @@ jobs:
 
       # Dependencies are needed here to run `yarn firbase` command
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -237,7 +237,7 @@ jobs:
           node-version: '14'
 
       - name: Get cached dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        uses: actions/cache@v2
         with:
           path: |
             node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - id: build
         run: echo "::set-output name=hash::${{ hashFiles('bin/**', 'content/**', 'firebase/**', 'functions/src/**', 'src/**', 'static/**', '**/package.json', '**/yarn.lock') }}"
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -189,7 +189,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458  # v2.5.0
         with:


### PR DESCRIPTION
- Use v3 of actions/checkout
- Use v3 of actions/setup-node
- Use v2 of actions/cache
