### PR TITLE
Add links to the Knowledge Base throughout data documentation

### DIFF
--- a/content/geoip/docs/databases/anonymous-ip.mdx
+++ b/content/geoip/docs/databases/anonymous-ip.mdx
@@ -71,6 +71,8 @@ These are named `GeoIP2-Anonymous-IP-Blocks-IPv4.csv` and
         <td>boolean</td>
         <td>
           1 if the IP address belongs to any sort of anonymous network. Blank if not.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408208507163-Anonymizer-and-Proxy-Data#h_01FN9BBGV3ZG3TC0357Q9Y07C6" target="_blank" rel="nofollow noopener noreferrer">Learn more about anonymizer and proxy detection on our Knowledge Base.</a>
         </td>
     </tr>
 
@@ -83,6 +85,8 @@ These are named `GeoIP2-Anonymous-IP-Blocks-IPv4.csv` and
           If a VPN provider does not register subnets under names associated with
           them, we will likely only flag their IP ranges using the
           `is_hosting_provider` flag.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDVJKNQY02XXFRM31N7SS2" target="_blank" rel="nofollow noopener noreferrer">Learn more about VPNs on our Knowledge Base.</a>
         </td>
     </tr>
 
@@ -92,19 +96,29 @@ These are named `GeoIP2-Anonymous-IP-Blocks-IPv4.csv` and
         <td>
           1 if the IP address belongs to a hosting or VPN provider (see
           description of `is_anonymous_vpn` flag). Blank if not.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDVXR9RQFMCY6SAWJM4YH0" target="_blank" rel="nofollow noopener noreferrer">Learn more about hosting providers used for anonymizing on our Knowledge Base.</a>
         </td>
     </tr>
 
     <tr>
         <td>is_public_proxy</td>
         <td>boolean</td>
-        <td>1 if the IP address belongs to a public proxy. Blank if not.</td>
+        <td>
+          1 if the IP address belongs to a public proxy. Blank if not.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDW5RZQCD4X4A76908DJ6Z" target="_blank" rel="nofollow noopener noreferrer">Learn more about public proxies on our Knowledge Base.</a>
+        </td>
     </tr>
 
     <tr>
         <td>is_tor_exit_node</td>
         <td>boolean</td>
-        <td>1 if the IP address is a Tor exit node. Blank if not.</td>
+        <td>
+          1 if the IP address is a Tor exit node. Blank if not.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDWR1VQR8A0NB3R8WXT8QF" target="_blank" rel="nofollow noopener noreferrer">Learn more about Tor exit nodes on our Knowledge Base.</a>
+        </td>
     </tr>
 
     <tr>
@@ -113,6 +127,8 @@ These are named `GeoIP2-Anonymous-IP-Blocks-IPv4.csv` and
         <td>
           1 if the IP address is on a suspected anonymizing network and belongs
           to a residential ISP. Blank if not.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDWEW3HAJT97P8EAZFQZMZ" target="_blank" rel="nofollow noopener noreferrer">Learn more about residential proxies on our Knowledge Base.</a>
         </td>
     </tr>
   </tbody>

--- a/content/geoip/docs/databases/asn.mdx
+++ b/content/geoip/docs/databases/asn.mdx
@@ -67,6 +67,8 @@ These are named `GeoLite2-ASN-Blocks-IPv4.csv` and
         <td>string</td>
         <td>
           The <a href="https://en.wikipedia.org/wiki/Autonomous_system_(Internet)">autonomous system</a> number associated with the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989WWSE56YD6AV4QSPSWDW" target="_blank" rel="nofollow noopener noreferrer">Learn more about autonomous system data on our Knowledge Base.</a>
         </td>
     </tr>
 
@@ -76,6 +78,8 @@ These are named `GeoLite2-ASN-Blocks-IPv4.csv` and
         <td>
           The organization associated with the registered autonomous system
           number for the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989WWSE56YD6AV4QSPSWDW" target="_blank" rel="nofollow noopener noreferrer">Learn more about autonomous system data on our Knowledge Base.</a>
         </td>
     </tr>
   </tbody>

--- a/content/geoip/docs/databases/connection-type.mdx
+++ b/content/geoip/docs/databases/connection-type.mdx
@@ -74,6 +74,8 @@ These are named `GeoIP2-Connection-Type-Blocks-IPv4.csv` and
         <td>
           One of the following values: `Cable/DSL`, `Corporate`, or
           `Cellular`. Additional values may be added in the future.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN988THBX8RVERNTZ12BY2EC" target="_blank" rel="nofollow noopener noreferrer">Learn more about connection type data on our Knowledge Base.</a>
         </td>
     </tr>
   </tbody>

--- a/content/geoip/docs/databases/domain.mdx
+++ b/content/geoip/docs/databases/domain.mdx
@@ -71,6 +71,8 @@ These are named `GeoIP2-Domain-Blocks-IPv4.csv` and
         <td>string</td>
         <td>
           The domain associated with the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN98A5BNTS0GGWTD2QA4AHXN" target="_blank" rel="nofollow noopener noreferrer">Learn more about domain name data on our Knowledge Base.</a>
         </td>
     </tr>
   </tbody>

--- a/content/geoip/docs/databases/isp.mdx
+++ b/content/geoip/docs/databases/isp.mdx
@@ -72,6 +72,8 @@ These are named `GeoIP2-ISP-Blocks-IPv4.csv` and
         <td>string</td>
         <td>
           The name of the ISP associated with the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989KHXR7TGXPB5T2DK0Q77" target="_blank" rel="nofollow noopener noreferrer">Learn more about ISP data on our Knowledge Base.</a>
         </td>
     </tr>
 
@@ -80,6 +82,8 @@ These are named `GeoIP2-ISP-Blocks-IPv4.csv` and
         <td>string</td>
         <td>
           The name of the organization associated with the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989KHXR7TGXPB5T2DK0Q77" target="_blank" rel="nofollow noopener noreferrer">Learn more about organization data on our Knowledge Base.</a>
         </td>
     </tr>
 
@@ -88,6 +92,8 @@ These are named `GeoIP2-ISP-Blocks-IPv4.csv` and
         <td>string</td>
         <td>
           The <a href="https://en.wikipedia.org/wiki/Autonomous_system_(Internet)">autonomous system</a> number associated with the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989WWSE56YD6AV4QSPSWDW" target="_blank" rel="nofollow noopener noreferrer">Learn more about autonomous system data on our Knowledge Base.</a>
         </td>
     </tr>
 
@@ -97,6 +103,8 @@ These are named `GeoIP2-ISP-Blocks-IPv4.csv` and
         <td>
           The organization associated with the registered autonomous system
           number for the IP address.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989WWSE56YD6AV4QSPSWDW" target="_blank" rel="nofollow noopener noreferrer">Learn more about autonomous system data on our Knowledge Base.</a>
         </td>
     </tr>
     <tr>
@@ -106,6 +114,8 @@ These are named `GeoIP2-ISP-Blocks-IPv4.csv` and
         The [mobile country code
         (MCC)](https://en.wikipedia.org/wiki/Mobile_country_code) associated
         with the IP address and ISP.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FT6Y6ANRH9GWYXE78B4RXAEX" target="_blank" rel="nofollow noopener noreferrer">Learn more about mobile country codes on our Knowledge Base.</a>
       </td>
     </tr>
     <tr>
@@ -115,6 +125,8 @@ These are named `GeoIP2-ISP-Blocks-IPv4.csv` and
         The [mobile network code
         (MNC)](https://en.wikipedia.org/wiki/Mobile_country_code) associated
         with the IP address and ISP.
+
+          \* <a href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FT6Y6ANRH9GWYXE78B4RXAEX" target="_blank" rel="nofollow noopener noreferrer">Learn more about mobile network codes on our Knowledge Base.</a>
       </td>
     </tr>
   </tbody>

--- a/content/geoip/docs/web-services/_schemas/ResponseCity.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseCity.mdx
@@ -24,6 +24,9 @@ import responseJson from '../_examples/geoip';
     type="integer"
   >
     A value from 0-100 representing our confidence that the city is correct.
+
+    [Learn more about confidence factors on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ)
   </Property>
 
   <Property
@@ -32,6 +35,9 @@ import responseJson from '../_examples/geoip';
   >
     A unique identifier for the city as specified by
     [GeoNames](https://www.geonames.org/).
+
+    [Learn more about GeoNames IDs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C)
   </Property>
 
   <Property
@@ -39,6 +45,9 @@ import responseJson from '../_examples/geoip';
   >
     A map from locale codes, such as `en`, to the localized names for the
     feature.
+
+    [Learn more about localized geolocation names on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q)
   </Property>
 
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseContinent.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseContinent.mdx
@@ -22,6 +22,9 @@ import responseJson from '../_examples/geoip';
     * `NA` – North America
     * `OC` – Oceania
     * `SA` – South America
+
+    [Learn more about continent codes on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRJSP2B14KSWWJTXKRWZGKJ)
   </Property>
 
   <Property
@@ -30,6 +33,9 @@ import responseJson from '../_examples/geoip';
   >
     A unique identifier for the continent as specified by
     [GeoNames](https://www.geonames.org/).
+
+    [Learn more about GeoNames IDs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C)
   </Property>
 
   <Property
@@ -37,5 +43,8 @@ import responseJson from '../_examples/geoip';
   >
     A map from locale codes, such as `en`, to the localized names for the
     feature.
+
+    [Learn more about localized geolocation names on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseCountry.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseCountry.mdx
@@ -20,6 +20,9 @@ import responseJson from '../_examples/geoip';
   >
     A unique identifier for the country as specified by
     [GeoNames](https://www.geonames.org/).
+
+    [Learn more about GeoNames IDs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C)
   </Property>
 
   <Property
@@ -34,6 +37,9 @@ import responseJson from '../_examples/geoip';
     type="integer"
   >
     A value from 0-100 representing our confidence that the country is correct.
+
+    [Learn more about confidence factors on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ)
   </Property>
 
   <Property
@@ -41,6 +47,9 @@ import responseJson from '../_examples/geoip';
   >
     This is `true` if the country is a member state of the European Union.
     Otherwise, the key is not included in the `country` object.
+
+    [Learn more about the European Union flag on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRMQN1B2WWTDM8HSQ20870M)
   </Property>
 
   <Property
@@ -51,6 +60,9 @@ import responseJson from '../_examples/geoip';
   >
     A two-character [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1)
     country code for the country associated with the IP address.
+
+    [Learn more about country codes on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRJSP2B14KSWWJTXKRWZGKJ)
   </Property>
 
   <Property
@@ -58,5 +70,8 @@ import responseJson from '../_examples/geoip';
   >
     A map from locale codes, such as `en`, to the localized names for the
     feature.
+
+    [Learn more about localized geolocation names on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseLocation.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseLocation.mdx
@@ -21,6 +21,9 @@ import responseJson from '../_examples/geoip';
     code) associated with the IP address. We have a 67% confidence that the
     location of the end-user falls within the area defined by the accuracy
     radius and the latitude and longitude coordinates.
+
+    [Learn about the geolocation area defined by latitude, longitude, and
+    accuracy radius, on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZZP6RAYSNZTYE4MQ3MWY)
   </Property>
 
   <Property
@@ -32,6 +35,9 @@ import responseJson from '../_examples/geoip';
   >
     The average annual income associated with the IP address in US dollars. This
     is only available for IP addresses in the US.
+
+    [Learn more about average income data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208479131-User-Context-Data#h_01FN9BTX4DQGT8W7JBX60A7PM5)
   </Property>
 
   <Property
@@ -49,10 +55,13 @@ import responseJson from '../_examples/geoip';
 
       The coordinates are not precise and should not be used to identify a
       particular street address or household. To better represent a level of
-      accuracy, please include the accuracy_radius when displaying latitude and
+      accuracy, please include the `accuracy_radius` when displaying latitude and
       longitude and make it clear that the coordinates refer to a larger
       geographical area instead of a precise location.
     </Alert>
+
+    [Learn about the geolocation area defined by latitude, longitude, and
+    accuracy radius, on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZZP6RAYSNZTYE4MQ3MWY)
   </Property>
 
   <Property
@@ -70,18 +79,20 @@ import responseJson from '../_examples/geoip';
 
       The coordinates are not precise and should not be used to identify a
       particular street address or household. To better represent a level of
-      accuracy, please include the accuracy_radius when displaying latitude and
+      accuracy, please include the `accuracy_radius` when displaying latitude and
       longitude and make it clear that the coordinates refer to a larger
       geographical area instead of a precise location.
     </Alert>
+
+    [Learn about the geolocation area defined by latitude, longitude, and
+    accuracy radius, on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZZP6RAYSNZTYE4MQ3MWY)
   </Property>
 
   <Property
     name="metro_code"
     type="integer"
   >
-    The metro code associated with the IP address. These are only available for
-    IP addresses in the US.
+    Metro code is a geolocation target code from Google.
   </Property>
 
   <Property
@@ -93,6 +104,9 @@ import responseJson from '../_examples/geoip';
   >
     The estimated number of people per square kilometer. This is only available
     for IP addresses in the US.
+
+    [Learn more about population density data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208479131-User-Context-Data#h_01FN9BTX4DQGT8W7JBX60A7PM5)
   </Property>
 
   <Property
@@ -101,5 +115,8 @@ import responseJson from '../_examples/geoip';
     The time zone associated with location, as specified by the
     [IANA Time Zone Database](https://www.iana.org/time-zones), e.g.,
     "America/New_York".
+
+    [Learn more about time zone data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRKYHGB5C5Y1G4Y3AW18PYC)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponsePostal.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponsePostal.mdx
@@ -28,6 +28,9 @@ import responseJson from '../_examples/geoip';
     * Portugal: 7 (accurate for the first 4. The last 3 often defaults to
     `-001`)
     * Singapore: 2
+
+    [Learn more about postal code data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRJSP2B14KSWWJTXKRWZGKJ)
   </Property>
 
   <Property
@@ -43,5 +46,8 @@ import responseJson from '../_examples/geoip';
   >
     A value from 0-100 representing our confidence that the postal code is
     correct.
+
+    [Learn more about confidence factors on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseRegisteredCountry.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseRegisteredCountry.mdx
@@ -9,12 +9,18 @@ import responseJson from '../_examples/geoip';
   A JSON object containing details about the country in which the ISP has
   registered the IP address.
 
+  [Learn about registered countries on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation)
+
   <Property
     name="geoname_id"
     type="integer"
   >
     A unique identifier for the country as specified by
     [GeoNames](https://www.geonames.org/).
+
+    [Learn more about GeoNames IDs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C)
   </Property>
 
   <Property
@@ -23,6 +29,9 @@ import responseJson from '../_examples/geoip';
     This is `true` if the registered country is a member state of the European
     Union. Otherwise, the key is not included in the `registered_country`
     object.
+
+    [Learn more about the European Union flag on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRMQN1B2WWTDM8HSQ20870M)
   </Property>
 
   <Property
@@ -33,6 +42,9 @@ import responseJson from '../_examples/geoip';
   >
     A two-character [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1)
     country code for the registered country.
+
+    [Learn more about ISO code data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRJSP2B14KSWWJTXKRWZGKJ)
   </Property>
 
   <Property
@@ -40,5 +52,8 @@ import responseJson from '../_examples/geoip';
   >
     A map from locale codes, such as `en`, to the localized names for the
     feature.
+
+    [Learn more about localized geolocation names on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseRepresentedCountry.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseRepresentedCountry.mdx
@@ -10,12 +10,18 @@ import responseJson from '../_examples/geoip';
   users of the IP address. For instance, the country represented by an overseas
   military base.
 
+  [Learn about represented countries on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation)
+
   <Property
     name="geoname_id"
     type="integer"
   >
     A unique identifier for the country as specified by
     [GeoNames](https://www.geonames.org/).
+
+    [Learn more about GeoNames IDs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C)
   </Property>
 
   <Property
@@ -24,6 +30,9 @@ import responseJson from '../_examples/geoip';
     This is `true` if the registered country is a member state of the European
     Union. Otherwise, the key is not included in the `represented_country`
     object.
+
+    [Learn more about the European Union flag on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRMQN1B2WWTDM8HSQ20870M)
   </Property>
 
   <Property
@@ -34,6 +43,9 @@ import responseJson from '../_examples/geoip';
   >
     A two-character [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1)
     country code for the represented_country country.
+
+    [Learn more about ISO code data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRJSP2B14KSWWJTXKRWZGKJ)
   </Property>
 
   <Property
@@ -48,5 +60,8 @@ import responseJson from '../_examples/geoip';
   >
     The type of represented country. Currently limited to `military`, but may
     include other types in the future.
+
+    [Learn more about localized geolocation names on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseSubdivision.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseSubdivision.mdx
@@ -24,6 +24,9 @@ import responseJson from '../_examples/geoip';
     type="integer"
   >
     A value from 0-100 representing our confidence that the region is correct.
+
+    [Learn more about confidence factors on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ)
   </Property>
 
   <Property
@@ -32,6 +35,9 @@ import responseJson from '../_examples/geoip';
   >
     A unique identifier for the region as specified by
     [GeoNames](https://www.geonames.org/).
+
+    [Learn more about GeoNames IDs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C)
   </Property>
 
   <Property
@@ -40,6 +46,9 @@ import responseJson from '../_examples/geoip';
     A string of up to three characters containing the region-portion of the
     [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code for the region
     associated with the IP address.
+
+    [Learn more about ISO code data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRJSP2B14KSWWJTXKRWZGKJ)
   </Property>
 
   <Property
@@ -47,5 +56,8 @@ import responseJson from '../_examples/geoip';
   >
     A map from locale codes, such as `en`, to the localized names for the
     feature.
+
+    [Learn more about localized geolocation names on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/_schemas/ResponseTraits.mdx
+++ b/content/geoip/docs/web-services/_schemas/ResponseTraits.mdx
@@ -17,6 +17,9 @@ import responseJson from '../_examples/geoip';
   >
     The [autonomous system number](https://en.wikipedia.org/wiki/Autonomous_system_(Internet))
     associated with the IP address.
+
+    [Learn more about autonomous system data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989WWSE56YD6AV4QSPSWDW)
   </Property>
 
   <Property
@@ -29,6 +32,9 @@ import responseJson from '../_examples/geoip';
     The organization associated with the registered
     [autonomous system number](https://en.wikipedia.org/wiki/Autonomous_system_(Internet))
     for the IP address.
+
+    [Learn more about autonomous system data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989WWSE56YD6AV4QSPSWDW)
   </Property>
 
   <Property
@@ -44,6 +50,9 @@ import responseJson from '../_examples/geoip';
     <Alert type="warning">
       This field is not present in the GeoLite2 City web service.
     </Alert>
+
+    [Learn more about domain name data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN98A5BNTS0GGWTD2QA4AHXN)
   </Property>
 
   <Property
@@ -61,6 +70,9 @@ import responseJson from '../_examples/geoip';
   >
     This is `true` if the IP address belongs to any sort of anonymous network.
     Otherwise, the key is not included in the `traits` object.
+
+    [Learn more about anonymizer and proxy detection on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208507163-Anonymizer-and-Proxy-Data#h_01FN9BBGV3ZG3TC0357Q9Y07C6)
   </Property>
 
   <Property
@@ -86,6 +98,9 @@ import responseJson from '../_examples/geoip';
     If a VPN provider does not register subnets under names associated with
     them, we will likely only flag their IP ranges using the
     `is_hosting_provider` flag.
+
+    [Learn more about VPNs on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDVJKNQY02XXFRM31N7SS2)
   </Property>
 
   <Property
@@ -97,6 +112,9 @@ import responseJson from '../_examples/geoip';
     This is `true` if the IP address belongs to a hosting or VPN provider
     (see description of `is_anonymous_vpn` flag). Otherwise, the key is not
     included in the `traits` object.
+
+    [Learn more about hosting providers used for anonymizing on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDVXR9RQFMCY6SAWJM4YH0)
   </Property>
 
   <Property
@@ -107,6 +125,9 @@ import responseJson from '../_examples/geoip';
   >
     This is `true` if the IP address belongs to a public proxy. Otherwise, the
     key is not included in the `traits` object.
+
+    [Learn more about public proxies on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDW5RZQCD4X4A76908DJ6Z)
   </Property>
 
   <Property
@@ -118,6 +139,9 @@ import responseJson from '../_examples/geoip';
     This is `true` if the IP address is on a suspected anonymizing network and
     belongs to a residential ISP (does not include peer-to-peer proxy IPs).
     Otherwise, the key is not included in the `traits` object.
+
+    [Learn more about residential proxies on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDWEW3HAJT97P8EAZFQZMZ)
   </Property>
 
   <Property
@@ -134,6 +158,9 @@ import responseJson from '../_examples/geoip';
   >
     This is `true` if the IP address is a Tor exit node. Otherwise, the key is
     not included in the `traits` object.
+
+    [Learn more about Tor exit nodes on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208507163#h_01G1EDWR1VQR8A0NB3R8WXT8QF)
   </Property>
 
   <Property
@@ -148,6 +175,9 @@ import responseJson from '../_examples/geoip';
     <Alert type="warning">
       This field is not present in the GeoLite2 City web service.
     </Alert>
+
+    [Learn more about ISP data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989KHXR7TGXPB5T2DK0Q77)
   </Property>
 
   <Property
@@ -162,6 +192,9 @@ import responseJson from '../_examples/geoip';
     <Alert type="warning">
       This field is not present in the GeoLite2 City web service.
     </Alert>
+
+    [Learn more about mobile country code data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FT6Y6ANRH9GWYXE78B4RXAEX)
   </Property>
 
   <Property
@@ -176,6 +209,9 @@ import responseJson from '../_examples/geoip';
     <Alert type="warning">
       This field is not present in the GeoLite2 City web service.
     </Alert>
+
+    [Learn more about mobile network code data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FT6Y6ANRH9GWYXE78B4RXAEX)
   </Property>
 
   <Property
@@ -199,6 +235,9 @@ import responseJson from '../_examples/geoip';
     <Alert type="warning">
       This field is not present in the GeoLite2 City web service.
     </Alert>
+
+    [Learn more about organization data on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989KHXR7TGXPB5T2DK0Q77)
   </Property>
 
   <Property
@@ -220,6 +259,9 @@ import responseJson from '../_examples/geoip';
 
     This indicator can be useful for deciding whether an IP address represents
     the same user over time.
+
+    [Learn more about the static IP score on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208479131-User-Context-Data#h_01FN9BSX7X351J8PV0WCH0E88F)
   </Property>
 
   <Property
@@ -232,6 +274,9 @@ import responseJson from '../_examples/geoip';
     The estimated number of users sharing the IP/network during the past 24
     hours. For IPv4, the count is for the individual IP. For IPv6, the count
     is for the /64 network.
+
+    [Learn more about the user count on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208479131-User-Context-Data#h_01FN9BT5PC591YRNBFZGHDYNS6)
   </Property>
 
   <Property
@@ -258,5 +303,8 @@ import responseJson from '../_examples/geoip';
     * `school`
     * `search_engine_spider`
     * `traveler`
+
+    [Learn more about the user type on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408208479131-User-Context-Data#h_01FN9BTGFQVP41YNPDGM454T2T)
   </Property>
 </GeoIpSchema>

--- a/content/geoip/docs/web-services/requests.mdx
+++ b/content/geoip/docs/web-services/requests.mdx
@@ -82,3 +82,9 @@ either `score`, `insights`, or `factors` as appropriate:
 If you set the `Accept-Charset` header in your client code, you must accept the
 `UTF-8` character set. If you don't you will receive a `406 Not Acceptable`
 response.
+
+## Troubleshooting IP Lookups
+
+[Learn about common troubleshooting steps to make sure that you're querying the
+correct IP addresses, and making efficient use of your queries, on our Knowledge
+Base.](https://support.maxmind.com/hc/en-us/articles/4408248823835-Optimize-my-Web-Service-Integration)

--- a/content/minfraud/api-documentation/_schemas/RequestAccount.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestAccount.mdx
@@ -20,9 +20,13 @@ import requestJson from '../_examples/request';
     login name for the account, but rather should be an internal ID that does
     not change. This is not your MaxMind account ID. No specific format is
     required.
+
+    [Learn more about the `/account/user_id` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452006111003#h_01G1E0XKAEF0BBC336545SY2AA)
   </Property>
 
   <Property
+    isDeprecated
     name="username_md5"
     tags={{
       'Max Length': 32,

--- a/content/minfraud/api-documentation/_schemas/RequestBilling.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestBilling.mdx
@@ -9,6 +9,9 @@ import requestJson from '../_examples/request';
   This object contains the billing address and contact information provided by
   the end-user who initiated the event.
 
+  [Learn more about the billing address inputs on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/5447224594075-Billing-and-Shipping-Inputs#h_01G0YN48RWENDYCKN2J3RQK2S3)
+
   <Property
     name="first_name"
     tags={{

--- a/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestCreditCard.mdx
@@ -18,6 +18,9 @@ import requestJson from '../_examples/request';
     The issuer ID number for the credit card. This is the first six or eight
     digits of the credit card number. It identifies the issuing bank. If you do
     not know whether the IIN is six or eight digits long, send us six digits.
+
+    [Learn more about the `/credit_card/issuer_id_number` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0YWJK0M3R4Y4N0AD2S6X9G4)
   </Property>
 
   <Property
@@ -32,6 +35,9 @@ import requestJson from '../_examples/request';
     that contains an eight digit IIN, and if the credit card brand is not one
     of the following, you should send the last two digits for `last_digits`:
     `Discover`, `JCB`, `Mastercard`, `UnionPay`, `Visa`.
+
+    [Learn more about the `/credit_card/last_digits` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0YWJW1KV6H4FEBWCMYA5HMW)
   </Property>
 
   <Property
@@ -46,9 +52,13 @@ import requestJson from '../_examples/request';
     a simple transformation of it. If you have a valid token that looks like a
     PAN but is not one, you may prefix that token with a fixed string, e.g.,
     `token-`.
+
+    [Learn more about the `/credit_card/token` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0YWHZK8D3N172REBAPXMQYY)
   </Property>
 
   <Property
+    isDeprecated
     name="bank_name"
     tags={{
       'Max Length': 255,
@@ -58,6 +68,7 @@ import requestJson from '../_examples/request';
   </Property>
 
   <Property
+    isDeprecated
     name="bank_phone_country_code"
     tags={{
       'Max Length': 4,
@@ -68,6 +79,7 @@ import requestJson from '../_examples/request';
   </Property>
 
   <Property
+    isDeprecated
     name="bank_phone_number"
     tags={{
       'Max Length': 255,
@@ -90,6 +102,9 @@ import requestJson from '../_examples/request';
     [`issuer_id_number`](#schema--request--credit-card__issuer_id_number) if
     you do not wish to pass partial account numbers, or if your payment
     processor does not provide them.
+
+    [Learn more about the `/credit_card/country` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0Z6QZAYZ74FCVPN2PHZ4ZA8)
   </Property>
 
   <Property
@@ -101,6 +116,9 @@ import requestJson from '../_examples/request';
     The address verification system (AVS) check result, as returned to you by
     the credit card processor. The minFraud service supports the standard AVS
     codes.
+
+    [Learn more about the `/credit_card/avs_result` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0YWK5CMEVG2YMTPQ11346QV)
   </Property>
 
   <Property
@@ -110,6 +128,9 @@ import requestJson from '../_examples/request';
     }}
   >
     The card verification value (CVV) code as provided by the payment processor.
+
+    [Learn more about the `/credit_card/cvv_result` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0YWK5CMEVG2YMTPQ11346QV)
   </Property>
 
   <Property
@@ -120,5 +141,8 @@ import requestJson from '../_examples/request';
     successful, or `false` if the customer failed verification. If 3-D Secure
     verification was not used, was unavailable, or resulted in another outcome
     other than success or failure, do not include this field.
+
+    [Learn more about the `/credit_card/was_3d_secure_successfil` input on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/5450338695963-Credit-Card-and-Payments-Inputs#h_01G0YWK5CMEVG2YMTPQ11346QV)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/RequestDevice.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestDevice.mdx
@@ -17,6 +17,9 @@ import requestJson from '../_examples/request';
     The IP address associated with the device used by the customer in the
     transaction. The IP address must be in IPv4 or IPv6 presentation format,
     i.e., dotted-quad notation or the IPv6 hexadecimal-colon notation.
+
+    [Get tips for how to pass the `/device/ip_address` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5444495353883-Device-Inputs#h_01G0YJ5QHRCS6JBJXJGWPB7DZB)
   </Property>
 
   <Property
@@ -26,6 +29,9 @@ import requestJson from '../_examples/request';
     }}
   >
     The HTTP `User-Agent` header of the browser used in the transaction.
+
+    [Learn more about the `/device/user_agent` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5444495353883-Device-Inputs#h_01G0YJ6YV72W9H65KZ3SEEM6CH)
   </Property>
 
   <Property
@@ -35,6 +41,9 @@ import requestJson from '../_examples/request';
     }}
   >
     The HTTP `Accept-Language` header of the device used in the transaction.
+
+    [Learn more about the `/device/accept_language` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5444495353883-Device-Inputs#h_01G0YJ6YV72W9H65KZ3SEEM6CH)
   </Property>
 
   <Property
@@ -48,6 +57,9 @@ import requestJson from '../_examples/request';
     The number of seconds between the creation of the user's session and the
     time of the transaction. Note that `session_age` is not the duration of the
     current visit, but the time since the start of the first visit.
+
+    [Learn more about the `/device/session_age` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5444495353883-Device-Inputs#h_01G0YJ77MFVS4XW63W9G2Y1Y65)
   </Property>
 
   <Property
@@ -57,5 +69,8 @@ import requestJson from '../_examples/request';
     }}
   >
     An ID that uniquely identifies a visitor's session on the site.
+
+    [Learn more about the `/device/session_id` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5444495353883-Device-Inputs#h_01G0YJ77MFVS4XW63W9G2Y1Y65)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/RequestEmail.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestEmail.mdx
@@ -19,11 +19,8 @@ import requestJson from '../_examples/request';
     This field must be either be a valid email address or an MD5 of the email
     used in the transaction.
 
-    <Alert type="warning">
-      If using the MD5 hash, please be sure to
-      [normalize it](/minfraud/normalizing-email-addresses-for-minfraud)
-      before calculating its MD5 hash.
-    </Alert>
+    [Learn more about the `/email/address` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5451485951387)
   </Property>
 
   <Property
@@ -34,5 +31,11 @@ import requestJson from '../_examples/request';
   >
     The domain of the email address used in the transaction. Do not include the
     `@` in this field.
+
+    <Alert type="warning">
+      You do not need to pass the email domain input unless you are passing the
+      email address as an MD5 hash. [Learn more about hashed email inputs on our
+      Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/5451485951387#h_01G0Z373C3H1QA68TTHVYMXGTT)
+    </Alert>
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/RequestEvent.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestEvent.mdx
@@ -17,6 +17,9 @@ import requestJson from '../_examples/request';
     Your internal ID for the transaction. We can use this to locate a specific
     transaction in our logs, and it will also show up in email alerts and
     notifications from us to you. No specific format is required.
+
+    [Learn more about the `/event/transaction_id` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452006111003-Event-and-Account-Inputs#h_01G1E0X7TPRN41NZHH9TRFWHVN)
   </Property>
 
   <Property
@@ -28,6 +31,9 @@ import requestJson from '../_examples/request';
     Your internal ID for the shop, affiliate, or merchant this order is coming
     from. Required for minFraud users who are resellers, payment providers,
     gateways and affiliate networks. No specific format is required.
+
+    [Learn more about the `/event/shop_id` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452006111003-Event-and-Account-Inputs#h_01G1E0WZ6PPV7VVKCKQM5N9960)
   </Property>
 
   <Property
@@ -43,6 +49,9 @@ import requestJson from '../_examples/request';
       as they occur.** However, it can be useful if you store transactions to be
       submitted to the service for scoring later.
     </Alert>
+
+    [Learn more about the `/event/time` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452006111003-Event-and-Account-Inputs#h_01G0Z3WBNAP5Y8WNRR156EJBBF)
   </Property>
 
   <Property
@@ -62,5 +71,8 @@ import requestJson from '../_examples/request';
     * `recurring_purchase`
     * `referral`
     * `survey`
+
+    [Learn more about the `/event/type` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452006111003-Event-and-Account-Inputs#h_01G0Z3WMWJW3QMHN8AGWK054E6)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/RequestOrder.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestOrder.mdx
@@ -17,6 +17,9 @@ import requestJson from '../_examples/request';
     }}
   >
     The total order amount for the transaction before taxes and discounts.
+
+    [Learn more about the `/order/amount` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z50FDAR22FR731C0CD2AE4)
   </Property>
 
   <Property
@@ -27,6 +30,9 @@ import requestJson from '../_examples/request';
   >
     The [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217) for the
     currency used in the transaction.
+
+    [Learn more about the `/order/currency` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z50FDAR22FR731C0CD2AE4)
   </Property>
 
   <Property
@@ -37,6 +43,9 @@ import requestJson from '../_examples/request';
   >
     The discount code applied to the transaction. If multiple discount codes
     were used, please separate them with a comma.
+
+    [Learn more about the `/order/discount_code` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z50ZVZ2GMAF4DG4N0FA73W)
   </Property>
 
   <Property
@@ -47,6 +56,9 @@ import requestJson from '../_examples/request';
   >
     The ID of the affiliate where the order is coming from. No specific format
     is required.
+
+    [Learn more about the `/order/affiliate_id` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z50Q0MRXQ5R52EF34E6G7J)
   </Property>
 
   <Property
@@ -57,6 +69,9 @@ import requestJson from '../_examples/request';
   >
     The ID of the sub-affiliate where the order is coming from. No specific
     format is required.
+
+    [Learn more about the `/order/subaffiliate_id` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z50Q0MRXQ5R52EF34E6G7J)
   </Property>
 
   <Property
@@ -67,17 +82,26 @@ import requestJson from '../_examples/request';
   >
     The URI of the referring site for this order. Needs to be absolute and have
     a URI scheme such as `https://`.
+
+    [Learn more about the `/order/referrer_uri` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z50Q0MRXQ5R52EF34E6G7J)
   </Property>
 
   <Property
     name="is_gift"
   >
     Whether order was marked as a gift by the purchaser.
+
+    [Learn more about the `/order/is_gift` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z517AZEMSN8V3GWTV131S6)
   </Property>
 
   <Property
     name="has_gift_message"
   >
     Whether the purchaser included a gift message.
+
+    [Learn more about the `/order/has_gift_message` input on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z517AZEMSN8V3GWTV131S6)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/RequestShipping.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestShipping.mdx
@@ -9,6 +9,9 @@ import requestJson from '../_examples/request';
   This object contains the shipping address and contact information provided
   by the end-user who initiated the event.
 
+  [Learn more about the shipping address inputs on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/5447224594075-Billing-and-Shipping-Inputs#h_01G0YN4GGRCC99P2HH0X54RFVA)
+
   <Property
     name="first_name"
     tags={{

--- a/content/minfraud/api-documentation/_schemas/RequestShoppingCart.mdx
+++ b/content/minfraud/api-documentation/_schemas/RequestShoppingCart.mdx
@@ -8,8 +8,6 @@ import requestJson from '../_examples/request';
   This is an _array_ of [shopping cart item objects](#schema--request--shopping-cart--item).
   A shopping cart should consist of an array of one or more item objects.
 
-  For instance, the response for Oxford in the United Kingdom would have an
-  object for England as the first element in `subdivisions` array and an object
-  for Oxfordshire as the second element. The `subdivisions` array for
-  Minneapolis in the United States will have a single object for Minnesota.
+  [Learn more about the shopping cart inputs on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/5452293435675-Order-and-Shopping-Cart-Inputs#h_01G0Z51P845R5DG7TCRNSKAD44)
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/Response.mdx
+++ b/content/minfraud/api-documentation/_schemas/Response.mdx
@@ -30,11 +30,14 @@ minFraud service you query and the inputs provided.
       'Max': 99,
     }}
   >
-    This field contains the risk score, from 0.01 to 99. A higher score
+    This field contains the overall risk score, from 0.01 to 99. A higher score
     indicates a higher risk of fraud. For example, a score of 20 indicates a
     20% chance that a transaction is fraudulent. We never return a risk score
     of 0, since all transactions have the possibility of being fraudulent.
     Likewise we never return a risk score of 100.
+
+    [Learn more about the overall risk score on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408382414235)
   </Property>
 
   <Property

--- a/content/minfraud/api-documentation/_schemas/ResponseBillingAddress.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseBillingAddress.mdx
@@ -21,6 +21,9 @@ import responseJson from '../_examples/response';
     for the postal-city match, which uses the [preferred place name](https://en.wikipedia.org/wiki/ZIP_Code#Preferred_place_names:_ZIP_Codes_and_previous_zoning_lines)
     for a US ZIP code. [Alternative place names](https://en.wikipedia.org/wiki/ZIP_Code#Preferred_place_names:_ZIP_Codes_and_previous_zoning_lines)
     for US ZIP codes may not trigger a match for this field.
+
+    [Learn how to use the postal to city check for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TV1Z2BRWCHVBK1ZE8276E)
   </Property>
 
   <Property
@@ -57,7 +60,13 @@ import responseJson from '../_examples/response';
     name="distance_to_ip_location"
     type="integer"
   >
-    The distance in kilometers from the address to the IP location. We fall back to country or subdivision information if we do not have postal or city information for an IP address, which may lead to inaccurate distance calculations. 
+    The distance in kilometers from the address to the IP location. We fall back
+    to country or subdivision information if we do not have postal or city
+    information for an IP address, which may lead to inaccurate distance
+    calculations.
+
+    [Learn how to use the IP geolocation to address distance for risk analysis
+    on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVDXWSBQR55FJ0K2KWGJQ)
   </Property>
 
   <Property
@@ -67,5 +76,8 @@ import responseJson from '../_examples/response';
     `false` when the address is not in the IP country. If the IP address could
     not be geolocated or no billing address was provided, the field will not be
     included in the response.
+
+    [Learn how to use the IP location to country check for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVDXWSBQR55FJ0K2KWGJQ)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseCommonAddressProperties.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseCommonAddressProperties.mdx
@@ -10,6 +10,9 @@
   for the postal-city match, which uses the [preferred place name](https://en.wikipedia.org/wiki/ZIP_Code#Preferred_place_names:_ZIP_Codes_and_previous_zoning_lines)
   for a US ZIP code. [Alternative place names](https://en.wikipedia.org/wiki/ZIP_Code#Preferred_place_names:_ZIP_Codes_and_previous_zoning_lines)
   for US ZIP codes may not trigger a match for this field.
+
+  [Learn how to use the postal to city check for risk analysis on our
+  Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TV1Z2BRWCHVBK1ZE8276E)
 </Property>
 
 <Property
@@ -47,6 +50,9 @@
   type="integer"
 >
   The distance in kilometers from the address to the IP location.
+
+  [Learn how to use the IP geolocation to address distance for risk analysis on
+  our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVDXWSBQR55FJ0K2KWGJQ)
 </Property>
 
 <Property
@@ -56,4 +62,7 @@
   `false` when the address is not in the IP country. If the IP address could
   not be geolocated or no billing address was provided, the field will not be
   included in the response.
+
+  [Learn how to use the IP location to country check for risk analysis on our
+  Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVDXWSBQR55FJ0K2KWGJQ)
 </Property>

--- a/content/minfraud/api-documentation/_schemas/ResponseCreditCard.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseCreditCard.mdx
@@ -27,6 +27,9 @@ import responseJson from '../_examples/response';
     }}
   >
     The card brand, such as "Visa", "Discover", "American Express", etc.
+
+    [Learn how to use the credit card brand data for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408734452123-Credit-Card-Risk-Data#h_01FN6TY3X4AHK80QZ85KXX6BZZ)
   </Property>
 
   <Property
@@ -40,6 +43,9 @@ import responseJson from '../_examples/response';
     card as determined by their billing address. In cases where the location of
     customers is highly mixed, this defaults to the country of the bank issuing
     the card.
+
+    [Learn how to use the credit card country data for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408734452123-Credit-Card-Risk-Data#h_01FN6TYNBCSRH25VWPQ1CGNN27)
   </Property>
 
   <Property
@@ -59,6 +65,9 @@ import responseJson from '../_examples/response';
     are missing, the key will not be present. In cases where the location of
     customers is highly mixed, the match is to the country of the bank issuing
     the card.
+
+    [Learn how to use the billing address to credit card country matching for
+    risk analysis on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVQNAXWEBB1T2JW4DNZAX)
   </Property>
 
   <Property
@@ -67,6 +76,9 @@ import responseJson from '../_examples/response';
     This field is `true` if the issuer ID number is for a prepaid card. It is
     `false` if the issuer ID number is for for a non-prepaid card. The key is
     only present when a valid issuer ID number has been provided.
+
+    [Learn how to use prepaid card detection for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408734452123-Credit-Card-Risk-Data#h_01FN6TXRB1E35Q7Z7BGENRV7MC)
   </Property>
 
   <Property
@@ -75,6 +87,9 @@ import responseJson from '../_examples/response';
     This field is `true` if the issuer ID number is for a virtual card. It is
     `false` if the issuer ID number is for a non-virtual card. The key is only
     present when a valid issuer ID number has been provided.
+
+    [Learn how to use virtual card detection for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408734452123-Credit-Card-Risk-Data#h_01FN6TXRB1E35Q7Z7BGENRV7MC)
   </Property>
 
   <Property

--- a/content/minfraud/api-documentation/_schemas/ResponseCreditCardIssuer.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseCreditCardIssuer.mdx
@@ -19,9 +19,13 @@ import responseJson from '../_examples/response';
     }}
   >
     This field contains a JSON object with information relating to the credit card issuer.
+
+    [Learn how to use the credit card issuer name for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408734452123-Credit-Card-Risk-Data#h_01FN6TY3X4AHK80QZ85KXX6BZZ)
   </Property>
 
   <Property
+  isDeprecated
     name="matches_provided_name"
   >
     This field is `true` if the name matches the name provided in the request
@@ -41,6 +45,7 @@ import responseJson from '../_examples/response';
   </Property>
 
   <Property
+    isDeprecated
     name="matches_provided_phone_number"
   >
     This field is `true` if the phone number matches the number provided in the

--- a/content/minfraud/api-documentation/_schemas/ResponseDevice.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseDevice.mdx
@@ -24,6 +24,9 @@ import responseJson from '../_examples/response';
     refers to a unique device as opposed to a cluster of similar devices. A
     confidence of 0.01 indicates very low confidence that the device is unique,
     whereas 99 indicates very high confidence.
+
+    [Learn how to use device confidence for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408634894107-Device-Risk-Data#h_01FN6V1ANY9XA76Z69HG2DZ5TJ)
   </Property>
 
   <Property
@@ -48,6 +51,9 @@ import responseJson from '../_examples/response';
   >
     The date and time of the last sighting of the device. The value is formatted
     according to [RFC 3339](https://tools.ietf.org/html/rfc3339).
+
+    [Learn how to use the last sighting data for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408634894107-Device-Risk-Data#h_01FN6V29YM8FA1A48G0N2G7VRW)
   </Property>
 
   <Property
@@ -59,5 +65,8 @@ import responseJson from '../_examples/response';
     The local date and time of the transaction in the time zone of the device.
     This is determined by using the UTC offset associated with the device.
     The value is formatted according to [RFC 3339](https://tools.ietf.org/html/rfc3339).
+
+    [Learn how to use local time data for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408634894107-Device-Risk-Data#h_01FN6V22JSGD7JP7Y3C9YBERHE)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseDisposition.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseDisposition.mdx
@@ -7,9 +7,11 @@ import responseJson from '../_examples/response';
   services="*"
 >
   This object contains information about how a request was handled by the
-  [custom rules](https://www.maxmind.com/en/solutions/minfraud-services/custom-rules)
-  you have defined. If your account does not have any custom rules defined, then
-  this object will not be present in the response.
+  custom rules you have defined. If your account does not have any custom rules
+  defined, then this object will not be present in the response.
+
+  [Learn about custom rules and dispositions on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/4408801942811-Use-Custom-Rules-and-Dispositions)
 
   <Property
     name="action"

--- a/content/minfraud/api-documentation/_schemas/ResponseEmail.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseEmail.mdx
@@ -26,6 +26,9 @@ import responseJson from '../_examples/response';
     A date string (e.g. 2017-04-24) to identify the date an email address was
     first seen by MaxMind. This is expressed using the ISO 8601 date format
     YYYY-MM-DD. The earliest date that may be returned is January 1, 2008.
+
+    [Learn how to use email first seen data for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408562891803-Email-Risk-Data#h_01FN6V59SHH0J0MRH041K46NE0)
   </Property>
 
   <Property
@@ -35,6 +38,9 @@ import responseJson from '../_examples/response';
     disposable email provider. It is `false` if the address is not from a known
     disposable email provider. The key will only be present if a valid email
     address or email domain is provided.
+
+    [Learn how to use disposable email detection for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408562891803-Email-Risk-Data#h_01FN6V5QYMX2DYRB4YSFM93F8D)
   </Property>
 
   <Property
@@ -44,6 +50,9 @@ import responseJson from '../_examples/response';
     free email provider such as Gmail or Yahoo! Mail. It is `false` if the
     domain is not for a known free email provider. The key will only be present
     if a valid email address or email domain is provided.
+
+    [Learn how to use free email detection for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408562891803-Email-Risk-Data#h_01FN6V5QYMX2DYRB4YSFM93F8D)
   </Property>
 
   <Property
@@ -54,5 +63,8 @@ import responseJson from '../_examples/response';
     is used for fraud. The key will only be present if a valid email address or
     email address hash is provided. Note that this is also factored into the
     overall `risk_score` in the response as well.
+
+    [Learn how to use our high risk email flag for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408562891803-Email-Risk-Data#h_01FN6V50N3JM0YV92SJMJSRR37)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseEmailDomain.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseEmailDomain.mdx
@@ -22,5 +22,8 @@ import responseJson from '../_examples/response';
     A date string (e.g. 2019-01-01) to identify the date an email address
     domain was first seen by MaxMind. This is expressed using the ISO 8601 date
     format `YYYY-MM-DD`. The earliest date that may be returned is January 1, 2019.
+
+    [Learn how to use email first seen data for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408562891803-Email-Risk-Data#h_01FN6V59SHH0J0MRH041K46NE0)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseIpAddress.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseIpAddress.mdx
@@ -38,6 +38,9 @@ import responseJson from '../_examples/response';
   >
     This field contains the risk associated with the IP address. The value
     ranges from 0.01 to 99. A higher score indicates a higher risk.
+
+    [Learn more about the IP risk score on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408382525851-Device-Risk-Scores#h_01FN6HE00G80Y22P4WSXJ81C6Y)
   </Property>
 
   <Property
@@ -74,5 +77,8 @@ import responseJson from '../_examples/response';
   >
     This array contains [IP Address Risk Reason objects](#schema--response--ip-address--risk-reason)
     identifying the reasons why the IP address received the associated risk.
+
+    [Learn how to use IP risk reasons for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408418812827-IP-Risk-Reasons)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseIpAddressRiskReason.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseIpAddressRiskReason.mdx
@@ -75,6 +75,9 @@ import responseJson from '../_examples/response';
         </tr>
       </tbody>
     </table>
+
+    [Learn how to use IP risk reasons for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408418812827-IP-Risk-Reasons)
   </Property>
 
   <Property
@@ -83,5 +86,8 @@ import responseJson from '../_examples/response';
     This field provides an explanation of the reason, as seen in the table
     above. The explanation text may change at any time and should not be matched
     against.
+
+    [Learn how to use IP risk reasons for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408418812827-IP-Risk-Reasons)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseIpAddressRiskReasons.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseIpAddressRiskReasons.mdx
@@ -8,4 +8,7 @@ import responseJson from '../_examples/response';
 >
   This array contains [IP Address Risk Reason objects](#schema--response--ip-address--risk-reason)
   identifying the reasons why the IP address received the associated risk.
+
+  [Learn how to use IP risk reasons for risk analysis on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/4408418812827-IP-Risk-Reasons)
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseShippingAddress.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseShippingAddress.mdx
@@ -16,6 +16,9 @@ import responseJson from '../_examples/response';
     fraudulent transactions. The field is `false` when the address is not
     associated with increased risk. The key will only be present when a
     shipping address is provided.
+
+    [Learn more about the flag for high risk shipping addresses on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TQP51E294G9ANGEHPC9ZY)
   </Property>
 
   <Property
@@ -30,6 +33,9 @@ import responseJson from '../_examples/response';
     for the postal-city match, which uses the [preferred place name](https://en.wikipedia.org/wiki/ZIP_Code#Preferred_place_names:_ZIP_Codes_and_previous_zoning_lines)
     for a US ZIP code. [Alternative place names](https://en.wikipedia.org/wiki/ZIP_Code#Preferred_place_names:_ZIP_Codes_and_previous_zoning_lines)
     for US ZIP codes may not trigger a match for this field.
+
+    [Learn how to use the postal to city check for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TV1Z2BRWCHVBK1ZE8276E)
   </Property>
 
   <Property
@@ -66,14 +72,26 @@ import responseJson from '../_examples/response';
     name="distance_to_ip_location"
     type="integer"
   >
-    The distance in kilometers from the address to the IP location. We fall back to country or subdivision information if we do not have postal or city information for an IP address, which may lead to inaccurate distance calculations. 
+    The distance in kilometers from the address to the IP location. We fall back
+    to country or subdivision information if we do not have postal or city
+    information for an IP address, which may lead to inaccurate distance
+    calculations.
+
+    [Learn how to use the IP geolocation to address distance for risk analysis
+    on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVDXWSBQR55FJ0K2KWGJQ)
   </Property>
 
   <Property
     name="distance_to_billing_address"
     type="integer"
   >
-    The distance in kilometers from the shipping address to billing address. We fall back to country or subdivision information if we do not have postal or city information for an IP address, which may lead to inaccurate distance calculations. 
+    The distance in kilometers from the shipping address to billing address. We
+    fall back to country or subdivision information if we do not have postal or
+    city information for an IP address, which may lead to inaccurate distance
+    calculations.
+
+    [Learn how to use the billing to shipping address distance for risk analysis
+    on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TREMWDMHSB6EW41XX1A0Y)
   </Property>
 
   <Property
@@ -83,5 +101,8 @@ import responseJson from '../_examples/response';
     `false` when the address is not in the IP country. If the IP address could
     not be geolocated or no billing address was provided, the field will not be
     included in the response.
+
+    [Learn how to use the IP location to country check for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408737039515-Billing-and-Shipping-Address-Risk-Data#h_01FN6TVDXWSBQR55FJ0K2KWGJQ)
   </Property>
 </MinFraudSchema>

--- a/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
+++ b/content/minfraud/api-documentation/_schemas/ResponseSubscores.mdx
@@ -9,9 +9,12 @@ import responseJson from '../_examples/response';
   ]}
 >
   This object contains risk factor scores for many of the individual components
-  that are used in calculating the `risk_score`.
+  that are used in calculating the `risk_score`. [Learn more about risk factor
+  scores on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408382645915-Risk-Factor-Scores)
 
-  This object is only included with [minFraud Factors](https://www.maxmind.com/en/solutions/minfraud-services/minfraud-factors).
+  This object is only included with minFraud Factors. [Learn more about the
+  differences between the minFraud services on our Knowledge
+  Base.](https://support.maxmind.com/hc/en-us/articles/4407833140123-Compare-the-minFraud-Services)
 
   <Property
     name="billing_address"
@@ -23,6 +26,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the billing address. If present, this is a value in
     the range 0.01 to 99.
+
+    [Learn how to use the billing address risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973621019-Billing-and-Shipping-Risk-Scores#h_01FN6R69DEYJREHS1XEGGMZP1Z)
   </Property>
 
   <Property
@@ -36,6 +42,9 @@ import responseJson from '../_examples/response';
     The risk associated with the distance between the billing address and the
     location for the given IP address. If present, this is a value in the range
     0.01 to 99.
+
+    [Learn how to use the billing address distance risk score for risk analysis
+    on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973621019-Billing-and-Shipping-Risk-Scores#h_01FN6R6NKC6EV11YECN55R32FB)
   </Property>
 
   <Property
@@ -48,6 +57,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the browser attributes such as the `User-Agent` and
     `Accept-Language`. If present, this is a value in the range 0.01 to 99.
+
+    [Learn how to use the browser risk score for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408382525851-Device-Risk-Scores#h_01FN6HFD5KWFEWANTE1WYS1HBY)
   </Property>
 
   <Property
@@ -63,6 +75,9 @@ import responseJson from '../_examples/response';
     available to
     users [sending chargeback data to MaxMind](/minfraud/report-a-transaction).
     If present, this is a value in the range 0.01 to 99.
+
+    [Learn how to use the chargeback risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408382525851-Device-Risk-Scores#h_01FN6HEPAK6034Z03NJCQ4F8EK)
   </Property>
 
   <Property
@@ -75,6 +90,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the country the transaction originated from. If
     present, this is a value in the range 0.01 to 99.
+
+    [Learn how to use the country risk score for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408382525851#h_01G1EBAN6V6E3EFHC4SC3J9K9M)
   </Property>
 
   <Property
@@ -88,6 +106,9 @@ import responseJson from '../_examples/response';
     The risk associated with the combination of IP country, card issuer country,
     billing country, and shipping country. If present, this is a value in the
     range 0.01 to 99.
+
+    [Learn how to use the country mismatch risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973728667-Order-Detail-Risk-Scores#h_01FN6RDP31Y1ST71YB7W58RFRS)
   </Property>
 
   <Property
@@ -100,6 +121,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the CVV result. If present, this is a value in the
     range 0.01 to 99.
+
+    [Learn how to use the CVV result risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410743622043-Credit-Card-Risk-Scores#h_01FN6RANC2E9Z6179XGNSNDWYJ)
   </Property>
 
   <Property
@@ -112,6 +136,13 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the device. If present, this is a value in the
     range 0.01 to 99.
+
+    You must have device tracking enabled on your site to receive this risk
+    factor score. [Learn more about device tracking on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4407973175451)
+
+    [Learn how to use the device risk score for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4408382525851-Device-Risk-Scores#h_01FN6HF0G2CJ5T15H3GJHNQ7XQ)
   </Property>
 
   <Property
@@ -124,6 +155,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the particular email address. If present, this is a
     value in the range 0.01 to 99.
+
+    [Learn how to use the email risk score for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4410757081243-Email-Risk-Scores#h_01FN6RDP31Y1ST71YB7W58RFRS)
   </Property>
 
   <Property
@@ -136,6 +170,9 @@ import responseJson from '../_examples/response';
   >
     The general risk associated with the email domain. If present, this is a
     value in the range 0.01 to 99.
+
+    [Learn how to use the email domain risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410757081243-Email-Risk-Scores#h_01FN6RE4TQ10DXYDG6C1QF6X9Y)
   </Property>
 
   <Property
@@ -149,6 +186,9 @@ import responseJson from '../_examples/response';
     	The risk associated with the email address local part (the part of the
       email address before the @ symbol). If present, this is a value in the
       range 0.01 to 99.
+
+    [Learn how to use the email local part risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410757081243-Email-Risk-Scores#h_01FN6REK9CWDR9V8NQ4WQPTGAD)
   </Property>
 
   <Property
@@ -160,8 +200,8 @@ import responseJson from '../_examples/response';
       'Max': 99,
     }}
   >
-    **This field has been deprecated.** Please use the `email_address` risk factor
-    instead.
+    **This field has been deprecated.** Please use the `email_address` risk
+    factor score instead.
   </Property>
 
   <Property
@@ -187,6 +227,9 @@ import responseJson from '../_examples/response';
     The risk associated with the particular issuer ID number (IIN) given the
     billing location and the history of usage of the IIN on your account and
     shop ID. If present, this is a value in the range 0.01 to 99.
+
+    [Learn how to use the IIN risk score for risk analysis on our Knowledge
+    Base.](https://support.maxmind.com/hc/en-us/articles/4410743622043-Credit-Card-Risk-Scores#h_01FN6RA2R69ZTGTS87VKVQ7F7G)
   </Property>
 
   <Property
@@ -199,6 +242,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the particular order amount for your account and
     shop ID. If present, this is a value in the range 0.01 to 99.
+
+    [Learn how to use the order amount risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973728667-Order-Detail-Risk-Scores#h_01FN6RE4TQ10DXYDG6C1QF6X9Y)
   </Property>
 
   <Property
@@ -211,6 +257,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the particular phone number. If present, this is a
     value in the range 0.01 to 99.
+
+    [Learn how to use the phone number risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973621019-Billing-and-Shipping-Risk-Scores#h_01FN6R7RDDBA09RJSRKDKSC1NJ)
   </Property>
 
   <Property
@@ -223,6 +272,9 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the shipping address. If present, this is a value
     in the range 0.01 to 99.
+
+    [Learn how to use the shipping address risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973621019-Billing-and-Shipping-Risk-Scores#h_01FN6R70AZHQGPME189XTH2SZW)
   </Property>
 
   <Property
@@ -236,6 +288,9 @@ import responseJson from '../_examples/response';
     The risk associated with the distance between the shipping address and the
     location for the given IP address. If present, this is a value in the range
     0.01 to 99.
+
+    [Learn how to use the shipping address distance risk score for risk analysis
+    on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973621019-Billing-and-Shipping-Risk-Scores#h_01FN6R7BQJAVT4KZZTK9Y3HBG6)
   </Property>
 
   <Property
@@ -248,5 +303,8 @@ import responseJson from '../_examples/response';
   >
     The risk associated with the local time of day of the transaction in the IP
     address location. If present, this is a value in the range 0.01 to 99.
+
+    [Learn how to use the time of day risk score for risk analysis on our
+    Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4410973728667-Order-Detail-Risk-Scores#h_01FN6REK9CWDR9V8NQ4WQPTGAD)
   </Property>
 </MinFraudSchema>

--- a/src/components/CsvBlockTable.tsx
+++ b/src/components/CsvBlockTable.tsx
@@ -76,6 +76,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
             </A>
             . This ID can be
             used to look up the location information in the Location file.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about GeoNames IDs on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -106,6 +115,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
             </A>
             . This ID can be
             used to look up the location information in the Location file.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about registered countries on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -125,7 +143,7 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
             The represented country is the country which is represented by
             users of the IP address. For instance, the country represented by
             an overseas military base. This column contains a unique
-            identifier for the network&apos;s registered country as specified
+            identifier for the network&apos;s represented country as specified
             by
             {' '}
             <A
@@ -137,6 +155,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
             </A>
             . This ID can be
             used to look up the location information in the Location file.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414762983195-Country-level-and-City-level-Geolocation"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about represented countries on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -252,6 +279,16 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
             </A>
             {' '}
             latitude of the location associated with the network.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZZP6RAYSNZTYE4MQ3MWY"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn about the geolocation area defined by latitude, longitude,
+              and accuracy radius, on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -280,6 +317,16 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
             </A>
             {' '}
             longitude of the location associated with the network.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZZP6RAYSNZTYE4MQ3MWY"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn about the geolocation area defined by latitude, longitude,
+              and accuracy radius, on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -299,14 +346,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
           <Td>
             The radius in kilometers around the specified location where the IP
             address is likely to be.
-            {' '}
+            <br/>
+            <br/>
             <A
-              // eslint-disable-next-line max-len
-              href="https://support.maxmind.com/hc/en-us/articles/4407630607131-Geolocation-Accuracy"
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZZP6RAYSNZTYE4MQ3MWY"
               rel="nofollow noopener noreferrer"
               target="_blank"
             >
-              Learn more about accuracy on our knowledge base.
+              Learn about the geolocation area defined by latitude, longitude,
+              and accuracy radius, on our Knowledge Base.
             </A>
           </Td>
           { !isEnterprise && (
@@ -329,6 +377,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
               <Td>
                 A identifier for the ISP. This ID can be used to look up the
                 location information in the ISP file.
+                <br/>
+                <br/>
+                <A
+                  href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN989KHXR7TGXPB5T2DK0Q77"
+                  rel="nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about ISP data on our Knowledge Base.
+                </A>
               </Td>
             </Tr>
             <Tr>
@@ -336,6 +393,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
               <Td>string</Td>
               <Td>
                 The domain associated with the network.
+                <br/>
+                <br/>
+                <A
+                  href="https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FN98A5BNTS0GGWTD2QA4AHXN"
+                  rel="nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about domain name data on our Knowledge Base.
+                </A>
               </Td>
             </Tr>
             <Tr>
@@ -343,6 +409,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
               <Td>decimal (1-100)</Td>
               <Td>
                 The confidence that the country was correctly geolocated.
+                <br/>
+                <br/>
+                <A
+                  href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ"
+                  rel="nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about confidence factors on our Knowledge Base.
+                </A>
               </Td>
             </Tr>
             <Tr>
@@ -351,6 +426,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
               <Td>
                 The confidence that the most specific subdivision was correctly
                 geolocated.
+                <br/>
+                <br/>
+                <A
+                  href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ"
+                  rel="nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about confidence factors on our Knowledge Base.
+                </A>
               </Td>
             </Tr>
             <Tr>
@@ -358,6 +442,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
               <Td>decimal (1-100)</Td>
               <Td>
                 The confidence that the city was correctly geolocated.
+                <br/>
+                <br/>
+                <A
+                  href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ"
+                  rel="nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about confidence factors on our Knowledge Base.
+                </A>
               </Td>
             </Tr>
             <Tr>
@@ -365,6 +458,15 @@ const CsvBlockTable: React.FC<ICsvBlockTable> = (props) => {
               <Td>decimal (1-100)</Td>
               <Td>
                 The confidence that the postal code was correctly geolocated.
+                <br/>
+                <br/>
+                <A
+                  href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRHZ767N9MJJ21K9CW04WWQ"
+                  rel="nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about confidence factors on our Knowledge Base.
+                </A>
               </Td>
             </Tr>
             <Tr>

--- a/src/components/CsvLocationTable.tsx
+++ b/src/components/CsvLocationTable.tsx
@@ -45,6 +45,15 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
             </A>
             . This ID can be
             used as a key for the Location file.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about GeoNames IDs on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -134,6 +143,15 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
           <Td>string</Td>
           <Td>
             The continent name for this location in the file&apos;s locale.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about localized names on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -179,6 +197,15 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
           <Td>string</Td>
           <Td>
             The country name for this location in the file&apos;s locale.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about localized names on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -231,6 +258,15 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
             The subdivision name for this location in the file&apos;s locale.
             As with the subdivision code, this is the least specific
             subdivision for the location.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about localized names on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -284,6 +320,15 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
             The subdivision name for this location in the file&apos;s locale.
             As with the subdivision code, this is the most specific subdivision
             for the location.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about localized names on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -302,6 +347,15 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
           <Td>string</Td>
           <Td>
             The city name for this location in the file&apos;s locale.
+            <br/>
+            <br/>
+            <A
+              href="https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about localized names on our Knowledge Base.
+            </A>
           </Td>
           { !isEnterprise && (
             <Td>
@@ -319,8 +373,7 @@ const CsvLocationTable: React.FC<ICsvLocationTable> = (props) => {
           <Td>metro_code</Td>
           <Td>integer</Td>
           <Td>
-            The metro code associated with the IP address. These are only
-            available for networks in the US.
+            Metro code is a geolocation target code from Google.
           </Td>
           { !isEnterprise && (
             <Td>

--- a/test/e2e/broken-links.spec.ts
+++ b/test/e2e/broken-links.spec.ts
@@ -43,6 +43,10 @@ const getBrokenLinks = (): Promise<any> => new Promise((resolve, reject) => {
           return;
         }
 
+        if (statusCode === 403) {
+          return;
+        }
+
         if (
           statusCode === 401
           && origin === 'https://www.maxmind.com'


### PR DESCRIPTION
- In the GeoIP2 web services API schema
- In the minFraud services API schema
- In the GeoIP2 database documentation tables
- Update our description of `metro_code`