### PR TITLE
Update Sandbox Documentation for minFraud Legacy test data

### DIFF
--- a/content/_sandbox-limits.mdx
+++ b/content/_sandbox-limits.mdx
@@ -3,4 +3,4 @@ The Sandbox should not be used to test the capacity of the production web
 service in high volume situations.
 
 If you are running into the request limit and need help, please
-[reach out to our support team for assistance](https://dev.maxmind.com/minfraud/api-documentation/responses?lang=en#schema--response--warnings).
+[reach out to our support team for assistance](https://support.maxmind.com/hc/en-us/requests/new).

--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -859,17 +859,27 @@ authenticate your requests.
 
 You may only submit approved test data to the Sandbox version of the minFraud
 services. At this time, the only approved test transaction data are the three IP
-addresses listed below. You can submit transactions to Sandbox minFraud services
-with any of the following IP addresses:
+addresses listed below. You can submit transactions to Sandbox minFraud Legacy
+services with any of the following IP addresses as the required `i` (IP address
+input). [Learn more about Legacy inputs above.](#input)
 
-- `146.243.121.22`
-- `152.216.7.110`
-- `23.10.87.103`
+You should receive a minFraud response with risk scores and risk data.
 
-You should receive a valid minFraud response.
+The `proxyScore` output will contain a response within the range defined below:
+
+| Test IP Address Input | Test proxyScore Output Range |
+| --------------------- | ---------------------------- |
+| `146.243.121.22`      | 2 - 4                        |
+| `152.216.7.110`       | 0.5 - 1.99                   |
+| `23.10.87.103`        | 0 - 0.49                     |
+
+Here is an example request that should return a valid minFraud response without
+any warnings or errors, and with a proxyScore between 2 and 4:
+
+- `https://minfraud.sandbox.maxmind.com/minfraud/v1.0/legacy?i=146.243.121.22&license_key=<your_sandbox_license_key>&country=US`
 
 You should not submit real transaction data to the Sandbox version of the
-minFraud services, but you can submit transactions with dummy data.
+minFraud Legacy services, but you can submit transactions with dummy data.
 
 The Sandbox environment imposes volume limits on API requests to prevent abuse.
 The Sandbox should not be used to test the capacity of the production web

--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -881,13 +881,6 @@ any warnings or errors, and with a proxyScore between 2 and 4:
 You should not submit real transaction data to the Sandbox version of the
 minFraud Legacy services, but you can submit transactions with dummy data.
 
-The Sandbox environment imposes volume limits on API requests to prevent abuse.
-The Sandbox should not be used to test the capacity of the production web
-service in high volume situations.
-
-If you are running into the request limit and need help, please
-[reach out to our support team for assistance](https://support.maxmind.com/hc/en-us/requests/new).
-
 <SandboxLimits />
 
 ### Learn more about the MaxMind Sandbox


### PR DESCRIPTION
minFraud legacy sandbox service now has reliable test outputs for the proxyScore