### PR TITLE
Disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 200
+    # Disable version updates
+    open-pull-requests-limit: 0
 
   - package-ecosystem: npm
     directory: "/functions"
     schedule:
       interval: daily
-    open-pull-requests-limit: 200
+    # Disable version updates
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+    # Disable version updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This will disable non-security updates. See [the docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#:~:text=If%20you%20only%20require%20security%20updates%20and%20want%20to%20exclude%20version%20updates%2C%20you%20can%20set%20open%2Dpull%2Drequest%2Dlimit%20to%200%20in%20order%20to%20prevent%20version%20updates%20for%20a%20given%20package%2Decosystem).
