### PR TITLE
Add husky setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,13 @@ If you need help installing and/or managing Node and Yarn versions, check out [N
 ### Installation
 
 ```sh
-npm install
+npm install && npm prepare
 ```
+
+#### Explanation
+
+* `npm install` installs the neccessary node modules for development.
+* `npm prepare` sets up the linting pre-commit hooks via husky.
 
 ### Development
 

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "lint:json": "eslint . --ext json",
     "lint:scripts": "tsc && eslint . --ext js,ts,tsx --ignore-pattern 'functions/**/*.js'",
     "lint:styles": "stylelint ./src/**/*.{css,scss,sass}",
+    "prepare": "husky install",
     "preview": "firebase hosting:channel:deploy $(git rev-parse --abbrev-ref HEAD)",
     "serve": "firebase emulators:start --only functions,hosting",
     "sitemap-query-string": "node ./bin/sitemap-query-string.js",


### PR DESCRIPTION
Husky used to [autoinstall](https://blog.typicode.com/husky-git-hooks-autoinstall/) the script called by its precommit hook.  This adds instructions for adding it manually.