### PR TITLE
Fix status_code parsing in maintenance banner

### DIFF
--- a/src/hooks/useSystemStatus.tsx
+++ b/src/hooks/useSystemStatus.tsx
@@ -65,7 +65,7 @@ const useSystemStatus = (): null | SystemStatus => {
   )
     .then(res => res.json())
     .then(json => {
-      const status_code = Number(json.result.status_overall);
+      const status_code = Number(json.result.status_overall.status_code);
       if (!(status_code in status)) {
         throw new TypeError('status_code invalid');
       }


### PR DESCRIPTION
It was hard to spot this because we swallow all errors in the `catch`.