### PR TITLE
Use "client API" throughtout the docs

### DIFF
--- a/content/contribute.mdx
+++ b/content/contribute.mdx
@@ -22,8 +22,8 @@ While MaxMind does not support or maintain unofficial APIs, you can get a
 feeling for the quality of contributions that we feature:
 
 - [minFraud service Magento 2 Plugin](https://www.weltpixel.com/magento2-maxmind-fraud-prevention-minfraud.html)
-- [GeoIP2 and GeoLite2 web services Unofficial APIs](/geoip/docs/web-services/#third-party-api-clients)
-- [GeoIP2 and GeoLite2 database Unofficial APIs](/geoip/docs/databases/#unofficial-api-clients)
+- [GeoIP2 and GeoLite2 web services Unofficial APIs](/geoip/docs/web-services/#third-party-client-apis)
+- [GeoIP2 and GeoLite2 database Unofficial APIs](/geoip/docs/databases/#unofficial-client-apis)
 - [GeoIP2 and GeoLite2 database Integrations (for MMDB format)](/geoip/docs/databases/#integrations)
 
 You can also peruse our organization and projects on GitHub to get a sense of

--- a/content/geoip/docs/databases.mdx
+++ b/content/geoip/docs/databases.mdx
@@ -80,9 +80,9 @@ import {
   </LinkGroup>
 </LinkGroupContainer>
 
-## API Clients
+## Client APIs
 
-### Official API Clients
+### Official Client APIs
 
 | Language or Framework | Package Repository                                                                                                            | Documentation                                              | Version Control                                    |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------- |
@@ -96,7 +96,7 @@ import {
 | Python                | [PyPI](https://pypi.python.org/pypi/geoip2)                                                                                   | [Read the Docs](https://geoip2.readthedocs.org/en/latest/) | [GitHub](https://github.com/maxmind/GeoIP2-python) |
 | Ruby                  | [RubyGems](https://rubygems.org/gems/maxmind-geoip2)                                                                          | [RubyDoc](https://www.rubydoc.info/gems/maxmind-geoip2)    | [GitHub](https://github.com/maxmind/GeoIP2-ruby)   |
 
-### Unofficial API Clients
+### Unofficial Client APIs
 
 <Alert type="warning">
   **Use at your own risk.**

--- a/content/geoip/docs/databases/_apis.mdx
+++ b/content/geoip/docs/databases/_apis.mdx
@@ -1,3 +1,3 @@
 You can find a complete list of official and unofficial client APIs, and
 third-party integrations on the
-[database documentation page](/geoip/docs/databases#api-clients).
+[database documentation page](/geoip/docs/databases#client-apis).

--- a/content/geoip/docs/databases/_binary-databases.mdx
+++ b/content/geoip/docs/databases/_binary-databases.mdx
@@ -1,7 +1,7 @@
 Binary databases make use of the
 [MaxMind DB file format](https://maxmind.github.io/MaxMind-DB/). MaxMind
-provides official API clients in the language listed below. The following API
-clients are open source and licensed under the Apache License, Version 2.0.
+provides official client APIs in the language listed below. The following client
+APIs are open source and licensed under the Apache License, Version 2.0.
 
 You can also use the [mmdbinspect tool](https://github.com/maxmind/mmdbinspect)
 (in beta), a command line interface built with Go, to look up one or more IPs

--- a/content/geoip/docs/web-services.mdx
+++ b/content/geoip/docs/web-services.mdx
@@ -21,9 +21,9 @@ service, review our
 [minFraud Service Comparison page](https://www.maxmind.com/en/solutions/minfraud-services#compare-features)
 and the Response Body section below.
 
-## API Clients
+## Client APIs
 
-### Official API Clients
+### Official Client APIs
 
 <table>
   <thead>
@@ -86,7 +86,7 @@ and the Response Body section below.
   </tbody>
 </table>
 
-### Third-Party API Clients
+### Third-Party Client APIs
 
 <Alert type="warning">
   **_Use at your own risk._** MaxMind does not offer support for these APIs and

--- a/content/geoip/geolite2-free-geolocation-data.mdx
+++ b/content/geoip/geolite2-free-geolocation-data.mdx
@@ -88,7 +88,7 @@ GeoLite2 product line to the paid GeoIP2 product line extremely easy.
 ### Databases
 
 See our
-[Database Documentation page](/geoip/docs/databases#official-api-clients) for a
+[Database Documentation page](/geoip/docs/databases#official-client-apis) for a
 list of available APIs. GeoIP2 APIs may be used with GeoLite2 binary databases
 (MMDB). You can also use the
 [GeoIP Update program](/geoip/updating-databases/#using-geoip-update) to
@@ -101,7 +101,7 @@ but they may contain fewer data points.
 ### Web services
 
 See our
-[Web Services Documentation page](/geoip/docs/web-services#official-api-clients)
+[Web Services Documentation page](/geoip/docs/web-services#official-client-apis)
 for a list of available web service APIs. GeoIP2 web service APIs may be used
 with the GeoLite2 web services by changing the hostname to the appropriate
 [GeoLite2 web service URI](/geoip/docs/web-services/requests#geolite2-endpoints).

--- a/content/geoip/geolocate-an-ip/databases.mdx
+++ b/content/geoip/geolocate-an-ip/databases.mdx
@@ -11,7 +11,7 @@ configuring a database reader and querying the database.
 ## Implementation
 
 MaxMind offers and highly recommends using
-[official client libraries](/geoip/docs/databases?lang=en#official-api-clients)
+[official client libraries](/geoip/docs/databases?lang=en#official-client-apis)
 to query our databases.
 
 ### 1. Install the GeoIP2 client library

--- a/content/geoip/geolocate-an-ip/web-services.mdx
+++ b/content/geoip/geolocate-an-ip/web-services.mdx
@@ -11,7 +11,7 @@ configuring a web service client, creating a request, and handling the response.
 ## Implementation
 
 MaxMind offers and highly recommends using
-[official client libraries](/geoip/docs/web-services?lang=en#api-clients) to
+[official client libraries](/geoip/docs/web-services?lang=en#client-apis) to
 access our geolocation services. If you cannot or do not wish to use our client
 libraries, please review our
 [GeoIP2 API Documentation page](/geoip/docs/web-services/#request-and-response-api-references)
@@ -271,7 +271,7 @@ puts record.country.iso_code
 ## Client APIs
 
 You can find a complete list of official and third-party client APIs on the
-[web services documentation page](/geoip/docs/web-services#api-clients).
+[web services documentation page](/geoip/docs/web-services#client-apis).
 
 ## Command Line (curl) Examples
 

--- a/content/geoip/release-notes/2016.mdx
+++ b/content/geoip/release-notes/2016.mdx
@@ -47,7 +47,7 @@ household.
 
 For the binary databases and web service, this field will be available at
 `/location/accuracy_radius`. All official
-[GeoIP2 client APIs](/geoip/geolocate-an-ip/databases/#official-maxmind-api-clients)
+[GeoIP2 client APIs](/geoip/geolocate-an-ip/databases/#official-maxmind-client-apis)
 already support this field.
 
 **For the CSV databases, a new `accuracy_radius` column will be added to the end

--- a/content/geoip/release-notes/2020.mdx
+++ b/content/geoip/release-notes/2020.mdx
@@ -98,7 +98,7 @@ files:
 - GeoIP2-Anonymous-IP-Blocks-IPv6.csv
 
 **Binary MMDB file users:** You will need to update your
-[MMDB reader](/geoip/geolocate-an-ip/databases/#official-maxmind-api-clients) to
+[MMDB reader](/geoip/geolocate-an-ip/databases/#official-maxmind-client-apis) to
 support look-ups containing the new output when it is released.
 
 </ReleaseNote>

--- a/content/geoip/release-notes/2022.mdx
+++ b/content/geoip/release-notes/2022.mdx
@@ -605,7 +605,7 @@ developer's site.
 #### MMDB file users
 
 You may need to update your
-[MMDB reader](/geoip/docs/databases?lang=en#official-api-clients) to support
+[MMDB reader](/geoip/docs/databases?lang=en#official-client-apis) to support
 lookups containing the new output when it is released. You can find a sample
 MMDB file with `mobile_country_code` and `mobile_network_code` on our
 [GitHub page](https://github.com/maxmind/MaxMind-DB/tree/master/test-data).

--- a/content/minfraud/api-documentation.mdx
+++ b/content/minfraud/api-documentation.mdx
@@ -23,7 +23,7 @@ To better understand the differences between each minFraud service, review our
 and the
 [API response body documentation](https://dev.maxmind.com/minfraud/api-documentation/responses?lang=en#bodies).
 
-## API Clients
+## Client APIs
 
 <ApiClients />
 

--- a/content/minfraud/index.mdx
+++ b/content/minfraud/index.mdx
@@ -29,7 +29,7 @@ If you are Proxy Detection Legacy customer, please refer to our
 <LinkGroupContainer>
   <LinkGroup heading="Guides">
     <LinkGroupCard
-      description="Start evaluating your transactions by installing, configuring, and using a minFraud API client."
+      description="Start evaluating your transactions by installing, configuring, and using a minFraud client API."
       heading="Evaluate a Transaction"
       icon={FaRocket}
       to="/minfraud/evaluate-a-transaction"

--- a/content/minfraud/normalizing-email-addresses-for-minfraud.mdx
+++ b/content/minfraud/normalizing-email-addresses-for-minfraud.mdx
@@ -10,12 +10,12 @@ If you provide the email as an MD5 hash, it’s important that you normalize it
 before generating the hash. Otherwise minor, inconsequential differences could
 cause minFraud to consider it a different address.
 
-Our [API clients](/minfraud/api-documentation/#api-clients) do this for you if
+Our [client APIs](/minfraud/api-documentation/#client-apis) do this for you if
 you enable sending the MD5 hash. This is the recommended way to do this.
 
 ## Normalizing email addresses
 
-If you are not able to use our API clients, you can normalize an email address
+If you are not able to use our client APIs, you can normalize an email address
 yourself. Below are the steps to take to do this.
 
 1. Trim whitespace from both ends of the address.
@@ -41,7 +41,7 @@ yourself. Below are the steps to take to do this.
    email local part with the subdomain (i.e., `alias@user.fastmail.com` is
    replaced with `user@fastmail.com`).
 1. Fix common typos in domain names. You can see a list of typos we map in our
-   [Java API client](https://github.com/maxmind/minfraud-api-java/blob/main/src/main/java/com/maxmind/minfraud/request/Email.java#L24).
+   [Java client API](https://github.com/maxmind/minfraud-api-java/blob/main/src/main/java/com/maxmind/minfraud/request/Email.java#L24).
 1. Remove alias parts from the local part. For addresses at the `yahoo.com`
    domain, or other domains affiliated with Yahoo, this is everything after and
    including the first `-` character, if present. For addresses with all other
@@ -53,7 +53,7 @@ yourself. Below are the steps to take to do this.
 
 ## Examples
 
-You can review the code in our API clients see how to normalize an email address
+You can review the code in our client APIs see how to normalize an email address
 in various languages.
 
 - [.NET (C#)](https://github.com/maxmind/minfraud-api-dotnet/blob/main/MaxMind.MinFraud/Request/Email.cs#L150)


### PR DESCRIPTION
Historically, we have used "client API" but with the dev-site update,
"API clients" started showing up in several places. This is
inconsistent with our other usage and it is particularly confusing
for the database APIs. The naming probably could be better generally,
e.g., "database libraries" for the MMDB readers and "client libaries"
for the web service client libraries, but this at least brings
consistency with our usage elsewhere.
