### PR TITLE
Clean up archived release note pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [Static Server](#static-server)
 - [Testing](#testing)
 - [Deployments](#deployments)
+- [Updating Release Notes for the New Year](#updating-release-notes-for-the-new-year)
 
 ### Minimum Requirements
 
@@ -103,3 +104,23 @@ npm run build && npm run preview
 **Firebase function resources are shared throughout environments.** If two PRs
 have changes to Firebase functions, the deployed functions will be those of the
 PR whose `Firebase - Staging` GitHub workflow has run most recently.
+
+### Updating Release Notes for the New Year
+
+Whenever you create your first release note for a product category for a new
+year:
+
+1. Add a file called `<year>.mdx` to the `content/<product>/release-notes`
+folder. (e.g., `content/geoip/release-notes/2024.mdx`)
+2. Add the header to your new release note file with the title: `<Product> Release Notes`
+(e.g., `GeoIP2 Release Notes`)
+3. Add the RSS notification to the top of the new file.
+4. Change the `title:` field in the previous year's `mdx` file to read: `<Product> Release Notes - <Year> Archive`
+(e.g., `GeoIP2 Release Notes - 2023 Archive`)
+5. Remove the RSS notification from the top of the archived file.
+6. Update link to the release notes in the navigation menu (`content/navigation.tsx`)
+to point to the current year's pathway.
+7. Update the URL in the JS redirects (`firebase/redirects/release-notes/current-year.js`)
+to the current year's pathway.
+8. Update the URLs used to create RSS feeds (`gatsby/gatsby-config/index.ts`) to
+the current year's pathway.

--- a/content/geoip/release-notes/2022.mdx
+++ b/content/geoip/release-notes/2022.mdx
@@ -3,10 +3,6 @@ draft: false
 title: GeoIP2 Release Notes - 2022 Archive
 ---
 
-<Alert type="info">
-Subscribe to the [GeoIP2 release notes RSS feed](/geoip/release-notes/rss.xml).
-</Alert>
-
 <ReleaseNote date="2022-12-19" title="December Holiday Database Release Schedule">
 
 Due to the December holidays, we will not be providing database updates for

--- a/content/minfraud/release-notes/2022.mdx
+++ b/content/minfraud/release-notes/2022.mdx
@@ -1,11 +1,7 @@
 ---
 draft: false
-title: minFraud Release Notes
+title: minFraud Release Notes - 2022 Archive
 ---
-
-<Alert type="info">
-Subscribe to the [minFraud release notes RSS feed](/minfraud/release-notes/rss.xml).
-</Alert>
 
 <ReleaseNote date="2022-10-11" title="MaxMind Sandbox has Launched">
 We've launched a new Sandbox Environment for technical validation and testing of

--- a/firebase/redirects/release-notes/current-year.js
+++ b/firebase/redirects/release-notes/current-year.js
@@ -9,7 +9,7 @@ module.exports = [
     type: 302,
   },
   {
-    destination: '/minfraud/release-notes/2022',
+    destination: '/minfraud/release-notes/2023',
     source: '/minfraud/release-notes',
     type: 302,
   },

--- a/src/gatsby/gatsby-config/index.ts
+++ b/src/gatsby/gatsby-config/index.ts
@@ -134,7 +134,7 @@ export default {
           }),
           createReleaseNotesFeed({
             description: 'Release notes for MaxMind\'s minFraud product line',
-            inputUrl: '/minfraud/release-notes/2022',
+            inputUrl: '/minfraud/release-notes/2023',
             outputUrl: '/minfraud/release-notes/rss.xml',
             title: 'minFraud Release Notes',
           }),


### PR DESCRIPTION
I noticed that we don't include the RSS alert on archived pages, and the title of archived pages should be changed.