### PR TITLE
Fix GeoIP WS header docs

### DIFF
--- a/content/geoip/docs/web-services/requests.mdx
+++ b/content/geoip/docs/web-services/requests.mdx
@@ -73,15 +73,14 @@ The `Authorization` header is always required. See
 [Authorization and Security](#authorization-and-security) for more details.
 
 The `Accept` header for a request is entirely optional. If you do include one,
-you must accept one of the following, substituting the `[SERVICE-TYPE]` with
-either `score`, `insights`, or `factors` as appropriate:
+you must accept one of the following:
 
 - `application/json`
-- `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json`
-- `application/vnd.maxmind.com-minfraud-[SERVICE TYPE]+json; charset=UTF-8; version=2.0`
+- `application/vnd.maxmind.com-country+json`
+- `application/vnd.maxmind.com-country+json; charset=UTF-8; version=2.1`
 
-A request for any other MIME type will result in a `415 Unsupported Media Type`
-error.
+Substitute the appropriate service's type for "country". A request for any other
+MIME type will result in a `415 Unsupported Media Type` error.
 
 If you set the `Accept-Charset` header in your client code, you must accept the
 `UTF-8` character set. If you don't you will receive a `406 Not Acceptable`


### PR DESCRIPTION
The GeoIP WS docs have headers information that appear more appropriate for the minFraud web services. This PR updates that information with headers appropriate for the GeoIP web services.