### PR TITLE
Update docs for optional IP in minFraud Legacy

### DIFF
--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -791,8 +791,6 @@ current when they signed up for the service. The latest version is 1.3.
             The possible error codes are:
             <ul>
                <li><strong>INVALID_LICENSE_KEY</strong></li>
-               <li><strong>IP_REQUIRED</strong></li>
-               <li><strong>IP_NOT_FOUND</strong> – This error will be returned if the IP address is not valid, if it is not public, or if it is not in our GeoIP database.</li>
                <li><strong>MAX_REQUESTS_REACHED</strong> – This is returned when your account is out of queries.</li>
                <li><strong>LICENSE_REQUIRED</strong> – This is returned if you do not provide a license key at all.</li>
                <li><strong>PERMISSION_REQUIRED</strong> – This is returned if you do not have permission to use the service. Please contact support@maxmind.com for more information.</li>
@@ -803,6 +801,7 @@ current when they signed up for the service. The latest version is 1.3.
                <li><strong>CITY_NOT_FOUND</strong></li>
                <li><strong>CITY_REQUIRED</strong></li>
                <li><strong>INVALID_EMAIL_MD5</strong></li>
+               <li><strong>IP_NOT_FOUND</strong> – This warning will be returned if the IP address is not valid, if it is not public, or if it is not in our GeoIP database.</li>
                <li><strong>POSTAL_CODE_REQUIRED</strong></li>
                <li><strong>POSTAL_CODE_NOT_FOUND</strong></li>
             </ul>


### PR DESCRIPTION
Contrary to the old copy, `IP_NOT_FOUND` was sometimes a warning
previously. Now it is always a warning.
