### PR TITLE
IPs geolocated to Flushing resolving to Queens

### DIFF
--- a/content/geoip/release-notes/2023.mdx
+++ b/content/geoip/release-notes/2023.mdx
@@ -7,6 +7,17 @@ title: GeoIP2 Release Notes
 Subscribe to the [GeoIP2 release notes RSS feed](/geoip/release-notes/rss.xml).
 </Alert>
 
+<ReleaseNote date="2023-08-03" title="Resolving more networks to borough of Queens, New York">
+
+Starting with tomorrow's release we will begin resolving IPs that currently
+return the neighborhood of Flushing (Queens, NY) to the corresponding borough of
+Queens in the city name field.
+
+For more granular place identification (such as neighborhood), we recommend
+using the postal code where provided.
+
+</ReleaseNote>
+
 <ReleaseNote date="2023-08-01" title="New Satellite connection type">
 
 On Tuesday August 29, 2023 we will be adding a new connection type value,


### PR DESCRIPTION
**Note:** Do not merge until we confirm the changes went through as expected on Friday, August 3.