### PR TITLE
Make documentation match the outputs

### DIFF
--- a/content/minfraud/minfraud-legacy.mdx
+++ b/content/minfraud/minfraud-legacy.mdx
@@ -322,8 +322,8 @@ Here is an example of the output with just a few fields:
 
 `riskScore=13.2;distance=6;countryMatch=Yes;countryCode=US;freeMail=Yes`
 
-The API version column indicates in what version of the API a field was added.
-You can explicitly
+The API version column specifies the earliest API version in which a field is
+available. You can explicitly
 [ask for responses in older API formats](https://www.maxmind.com/en/minfraud_version).
 By default, all new users will receive responses for the version that was
 current when they signed up for the service. The latest version is 1.3.
@@ -359,7 +359,7 @@ current when they signed up for the service. The latest version is 1.3.
          <td>explanation</td>
          <td>string</td>
          <td><strong>This field has been deprecated, is not supported, and is no longer present in API version 1.3.</strong> This is a brief explanation of the <em>score</em> (not the <em>riskScore</em>).</td>
-         <td>1.0</td>
+         <td>1.1</td>
       </tr>
       <tr>
          <td colspan="4">
@@ -670,13 +670,13 @@ current when they signed up for the service. The latest version is 1.3.
             This field can be either <strong>Yes</strong>, <strong>No</strong>, <strong>NotFound</strong>, or <strong>NA</strong>.  It indicates whether the country of the billing address matches the country of the majority of customers using that BIN. In cases where the location of customers is highly mixed, the match is to the country of the bank issuing the card.
             The <strong>NotFound</strong> response means that we could not find a match for the provided <em>bin</em> input field. The <strong>NA</strong> response means that you did not provide a <em>bin</em> in the input.
          </td>
-         <td>1.1</td>
+         <td>1.0</td>
       </tr>
       <tr>
          <td>binCountry</td>
          <td>string (2)</td>
          <td>The two letter <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a> country code country code associated with the location of the majority of customers using this credit card as determined by their billing address. In cases where the location of customers is highly mixed, this defaults to the country of the bank issuing the card. <strong>This field is returned for premium service level queries. For standard service level queries the field is only returned if the <em>binMatch</em> is Yes.</strong></td>
-         <td>1.1</td>
+         <td>1.0</td>
       </tr>
       <tr>
          <td>binNameMatch</td>
@@ -700,13 +700,13 @@ current when they signed up for the service. The latest version is 1.3.
             This field can be either <strong>Yes</strong>, <strong>No</strong>, <strong>NotFound</strong>, or <strong>NA</strong> It indicates whether the credit card’s bank name matches the <em>binPhone</em> input field.
             The <strong>NotFound</strong> response means that we could not find a match for the provided <em>bin</em> input field. The <strong>NA</strong> response means that you did not provide a <em>binPhone</em> in the input.
          </td>
-         <td>1.1</td>
+         <td>1.0</td>
       </tr>
       <tr>
          <td>binPhone</td>
          <td>string</td>
          <td>The phone number of the bank which issued the credit card. This is available for approximately 75% of all BIN numbers. In some cases the phone number we return may be out of date. <strong>This field is only returned for premium service level queries.</strong></td>
-         <td>1.1</td>
+         <td>1.0</td>
       </tr>
       <tr>
          <td>prepaid</td>
@@ -770,13 +770,13 @@ current when they signed up for the service. The latest version is 1.3.
          <td>minfraud_version</td>
          <td>string</td>
          <td>This returns the API version that was used for this request.</td>
-         <td>1.0</td>
+         <td>1.3</td>
       </tr>
       <tr>
          <td>service_level</td>
          <td>enum</td>
          <td>This returns the service level that was used for this request. This can be either <strong>standard</strong> or <strong>premium</strong>.</td>
-         <td>1.0</td>
+         <td>1.3</td>
       </tr>
       <tr>
          <td colspan="4">


### PR DESCRIPTION
Some versions in the documentation does not match the fields of the output provided inside the response of the Legacy API. This commit updates the API versions to correct the versions.