### PR TITLE
correct date

### DIFF
--- a/content/geoip/release-notes/2023.mdx
+++ b/content/geoip/release-notes/2023.mdx
@@ -99,7 +99,7 @@ users. The Anycast flag will be released for MMDB users by the end of December,
 at the same that the flag is available in the GeoIP web services. The flag is a
 non-breaking change for MMDB format database users.
 
-The Anycast flag will be released in CSV format databases in mid-January, 2023.
+The Anycast flag will be released in CSV format databases in mid-January, 2024.
 In most cases, the addition of a new field to CSV databases should also be a
 non-breaking change, but you should check your integration to make sure that it
 can accommodate the addition of new fields.


### PR DESCRIPTION
A release note contained the wrong year.