### PR TITLE
update track devices snippet so it is consistent with the other snippet

### DIFF
--- a/content/minfraud/evaluate-a-transaction.mdx
+++ b/content/minfraud/evaluate-a-transaction.mdx
@@ -28,15 +28,17 @@ minimum, be included on the page where the IP address is captured for a minFraud
 query.
 
 Place the following code in the footer of the HTML webpage and replace
-`ACCOUNT_ID` with your
+`INSERT_MAXMIND_ACCOUNT_ID_HERE` with your
 [MaxMind account ID](https://support.maxmind.com/hc/en-us/articles/4412951066779-Find-my-Account-ID):
 
 ```html
-<script type="text/javascript">
-  maxmind_user_id = "ACCOUNT_ID";
+<script>
   (function() {
+    var mmapiws = window.__mmapiws = window.__mmapiws || {};
+    mmapiws.accountId = "INSERT_MAXMIND_ACCOUNT_ID_HERE";
     var loadDeviceJs = function() {
       var element = document.createElement('script');
+      element.async = true;
       element.src = 'https://device.maxmind.com/js/device.js';
       document.body.appendChild(element);
     };


### PR DESCRIPTION
The device tracking snippet exists in two places: `Evaluate a transaction` page and `Track devices` page. The snippet on the `Evaluate a transaction` page was not updated when the snippet on the `Track devices` page was, leading to confusion.

This PR updates the former to be consistent with the latter.