### PR TITLE
Add new third-party Go client to web service docs

### DIFF
--- a/content/geoip/docs/web-services.mdx
+++ b/content/geoip/docs/web-services.mdx
@@ -106,8 +106,8 @@ and the Response Body section below.
     <tr>
       <td>Go</td>
       <td></td>
-      <td>[GoDoc](https://godoc.org/github.com/savaki/geoip2)</td>
-      <td>[GitHub](https://github.com/savaki/geoip2)</td>
+      <td>[Go Packages](https://pkg.go.dev/github.com/iamvladw/GeoIP2-go)</td>
+      <td>[GitHub](https://github.com/iamvladw/GeoIP2-go)</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Also remove previous Go client as it hasn't been updated since 2015.
