### PR TITLE
Remove tronovav/geoip2-update

### DIFF
--- a/content/geoip/updating-databases.mdx
+++ b/content/geoip/updating-databases.mdx
@@ -216,22 +216,6 @@ This method only issues a HEAD request, rather than a download request, so
 running this check won’t count against your
 [daily database download limit](https://support.maxmind.com/hc/en-us/articles/4408216129947).
 
-## Third-party tools
-
-<Alert type="warning">
-  **_Use at your own risk._** MaxMind does not offer support for these tools
-  and has not reviewed the code.
-</Alert>
-
-The following tools have been developed by the community of GeoIP users. MaxMind
-does not offer support for these integrations, or maintain them. See
-[our guide on developing for the community](/contribute) if you have questions
-about creating or sharing your own unofficial tools.
-
-- [Geoip2 Update](https://github.com/tronovav/geoip2-update) - A PHP tool for
-  updating MaxMind GeoLite2 and GeoIP2 databases from your script or via
-  Composer.
-
 ## Changes to file size between updates
 
 It is expected for database files to increase or decrease in size from time to


### PR DESCRIPTION
As discussed in [this issue](https://github.com/tronovav/geoip2-update/issues/12),
this tool started proxying request through a server not controlled by
MaxMind. Given the potential security concerns (e.g., of a malicious
database as well as sharing the license key with a third party), we
can no longer recommend using this library.
