### PR TITLE
Add information about database file sizes

### DIFF
--- a/content/geoip/docs/databases/anonymous-ip.mdx
+++ b/content/geoip/docs/databases/anonymous-ip.mdx
@@ -163,6 +163,19 @@ These are named `GeoIP2-Anonymous-IP-Blocks-IPv4.csv` and
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoIP Anonymous IP',
+       csvsizerange: '4.31 MB - 4.75 MB',
+       mmdbsizerange: '2.69 MB - 2.87 MB',
+       ipv4range: '155,000 - 166,000',
+       ipv6range: '19,000 - 26,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="Anonymous IP" />

--- a/content/geoip/docs/databases/anonymous-ip.mdx
+++ b/content/geoip/docs/databases/anonymous-ip.mdx
@@ -165,13 +165,13 @@ These are named `GeoIP2-Anonymous-IP-Blocks-IPv4.csv` and
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoIP Anonymous IP',
-       csvsizerange: '4.31 MB - 4.75 MB',
-       mmdbsizerange: '2.69 MB - 2.87 MB',
-       ipv4range: '155,000 - 166,000',
-       ipv6range: '19,000 - 26,000'
+       databaseName: 'GeoIP Anonymous IP',
+       csvSizeRange: '4.31 MB - 4.75 MB',
+       mmdbSizeRange: '2.69 MB - 2.87 MB',
+       ipv4Range: '155,000 - 166,000',
+       ipv6Range: '19,000 - 26,000'
     }
   ]}
 />

--- a/content/geoip/docs/databases/asn.mdx
+++ b/content/geoip/docs/databases/asn.mdx
@@ -117,13 +117,13 @@ These are named `GeoLite2-ASN-Blocks-IPv4.csv` and
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoLite ASN',
-       csvsizerange: '27.69 MB - 28.09 MB',
-       mmdbsizerange: '8.41 MB - 8.56 MB',
-       ipv4range: '505,000 - 510,000',
-       ipv6range: '131,000 - 137,000'
+       databaseName: 'GeoLite ASN',
+       csvSizeRange: '27.69 MB - 28.09 MB',
+       mmdbSizeRange: '8.41 MB - 8.56 MB',
+       ipv4Range: '505,000 - 510,000',
+       ipv6Range: '131,000 - 137,000'
     }
   ]}
 />

--- a/content/geoip/docs/databases/asn.mdx
+++ b/content/geoip/docs/databases/asn.mdx
@@ -115,6 +115,19 @@ These are named `GeoLite2-ASN-Blocks-IPv4.csv` and
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoLite ASN',
+       csvsizerange: '27.69 MB - 28.09 MB',
+       mmdbsizerange: '8.41 MB - 8.56 MB',
+       ipv4range: '505,000 - 510,000',
+       ipv6range: '131,000 - 137,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="ASN" />

--- a/content/geoip/docs/databases/city-and-country.mdx
+++ b/content/geoip/docs/databases/city-and-country.mdx
@@ -159,6 +159,40 @@ blocks files have the same columns as the City database.
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoIP City',
+       csvsizerange: '577 MB - 606 MB',
+       mmdbsizerange: '108 MB - 110 MB',
+       ipv4range: '657,000 - 682,000',
+       ipv6range: '231,000 - 250,000'
+    },
+    {
+       databasename: 'GeoIP Country',
+       csvsizerange: '29.2 MB - 30.8 MB',
+       mmdbsizerange: '6.42 MB - 6.29 MB',
+       ipv4range: '480,000 - 502,000',
+       ipv6range: '265,000 - 280,000'
+    },
+    {
+       databasename: 'GeoLite City',
+       csvsizerange: '226.2 MB - 292.7 MB',
+       mmdbsizerange: '50 MB - 63.8 MB',
+       ipv4range: '236,000 - 334,000',
+       ipv6range: '114,000 - 123,000'
+    },
+    {
+       databasename: 'GeoLite Country',
+       csvsizerange: '30.58 MB - 30 MB',
+       mmdbsizerange: '6.38 MB - 6.64 MB',
+       ipv4range: '480,000 - 490,000',
+       ipv6range: '280,000 - 308,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="City and Country" />

--- a/content/geoip/docs/databases/city-and-country.mdx
+++ b/content/geoip/docs/databases/city-and-country.mdx
@@ -161,34 +161,34 @@ blocks files have the same columns as the City database.
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoIP City',
-       csvsizerange: '577 MB - 606 MB',
-       mmdbsizerange: '108 MB - 110 MB',
-       ipv4range: '657,000 - 682,000',
-       ipv6range: '231,000 - 250,000'
+       databaseName: 'GeoIP City',
+       csvSizeRange: '577 MB - 606 MB',
+       mmdbSizeRange: '108 MB - 110 MB',
+       ipv4Range: '657,000 - 682,000',
+       ipv6Range: '231,000 - 250,000'
     },
     {
-       databasename: 'GeoIP Country',
-       csvsizerange: '29.2 MB - 30.8 MB',
-       mmdbsizerange: '6.42 MB - 6.29 MB',
-       ipv4range: '480,000 - 502,000',
-       ipv6range: '265,000 - 280,000'
+       databaseName: 'GeoIP Country',
+       csvSizeRange: '29.2 MB - 30.8 MB',
+       mmdbSizeRange: '6.42 MB - 6.29 MB',
+       ipv4Range: '480,000 - 502,000',
+       ipv6Range: '265,000 - 280,000'
     },
     {
-       databasename: 'GeoLite City',
-       csvsizerange: '226.2 MB - 292.7 MB',
-       mmdbsizerange: '50 MB - 63.8 MB',
-       ipv4range: '236,000 - 334,000',
-       ipv6range: '114,000 - 123,000'
+       databaseName: 'GeoLite City',
+       csvSizeRange: '226.2 MB - 292.7 MB',
+       mmdbSizeRange: '50 MB - 63.8 MB',
+       ipv4Range: '236,000 - 334,000',
+       ipv6Range: '114,000 - 123,000'
     },
     {
-       databasename: 'GeoLite Country',
-       csvsizerange: '30.58 MB - 30 MB',
-       mmdbsizerange: '6.38 MB - 6.64 MB',
-       ipv4range: '480,000 - 490,000',
-       ipv6range: '280,000 - 308,000'
+       databaseName: 'GeoLite Country',
+       csvSizeRange: '30.58 MB - 30 MB',
+       mmdbSizeRange: '6.38 MB - 6.64 MB',
+       ipv4Range: '480,000 - 490,000',
+       ipv6Range: '280,000 - 308,000'
     }
   ]}
 />

--- a/content/geoip/docs/databases/connection-type.mdx
+++ b/content/geoip/docs/databases/connection-type.mdx
@@ -109,6 +109,19 @@ These are named `GeoIP2-Connection-Type-Blocks-IPv4.csv` and
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoIP Connection Type',
+       csvsizerange: '30.56 MB - 47.44 MB',
+       mmdbsizerange: '9.02 MB - 12.7 MB',
+       ipv4range: '933,000 - 155,000',
+       ipv6range: '197,000 - 208,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="Connection Type" />

--- a/content/geoip/docs/databases/connection-type.mdx
+++ b/content/geoip/docs/databases/connection-type.mdx
@@ -111,13 +111,13 @@ These are named `GeoIP2-Connection-Type-Blocks-IPv4.csv` and
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoIP Connection Type',
-       csvsizerange: '30.56 MB - 47.44 MB',
-       mmdbsizerange: '9.02 MB - 12.7 MB',
-       ipv4range: '933,000 - 155,000',
-       ipv6range: '197,000 - 208,000'
+       databaseName: 'GeoIP Connection Type',
+       csvSizeRange: '30.56 MB - 47.44 MB',
+       mmdbSizeRange: '9.02 MB - 12.7 MB',
+       ipv4Range: '933,000 - 155,000',
+       ipv6Range: '197,000 - 208,000'
     }
   ]}
 />

--- a/content/geoip/docs/databases/domain.mdx
+++ b/content/geoip/docs/databases/domain.mdx
@@ -107,6 +107,19 @@ These are named `GeoIP2-Domain-Blocks-IPv4.csv` and
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoIP Domain',
+       csvsizerange: '17.44 MB - 17.87 MB',
+       mmdbsizerange: '9.96 MB - 10.3 MB',
+       ipv4range: '502,000 - 508,000',
+       ipv6range: '97,000 - 107,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="Domain" />

--- a/content/geoip/docs/databases/domain.mdx
+++ b/content/geoip/docs/databases/domain.mdx
@@ -109,13 +109,13 @@ These are named `GeoIP2-Domain-Blocks-IPv4.csv` and
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoIP Domain',
-       csvsizerange: '17.44 MB - 17.87 MB',
-       mmdbsizerange: '9.96 MB - 10.3 MB',
-       ipv4range: '502,000 - 508,000',
-       ipv6range: '97,000 - 107,000'
+       databaseName: 'GeoIP Domain',
+       csvSizeRange: '17.44 MB - 17.87 MB',
+       mmdbSizeRange: '9.96 MB - 10.3 MB',
+       ipv4Range: '502,000 - 508,000',
+       ipv6Range: '97,000 - 107,000'
     }
   ]}
 />

--- a/content/geoip/docs/databases/enterprise.mdx
+++ b/content/geoip/docs/databases/enterprise.mdx
@@ -256,13 +256,13 @@ name would be "GeoIP2-City-Locations-en.csv".
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoIP Enterprise',
-       csvsizerange: '975 MB - 1.06 GB',
-       mmdbsizerange: '341 MB - 350 MB',
-       ipv4range: '8,064,000 - 8,733,000',
-       ipv6range: '2,933,000 - 3,151,000'
+       databaseName: 'GeoIP Enterprise',
+       csvSizeRange: '975 MB - 1.06 GB',
+       mmdbSizeRange: '341 MB - 350 MB',
+       ipv4Range: '8,064,000 - 8,733,000',
+       ipv6Range: '2,933,000 - 3,151,000'
     }
   ]}
 />

--- a/content/geoip/docs/databases/enterprise.mdx
+++ b/content/geoip/docs/databases/enterprise.mdx
@@ -254,6 +254,19 @@ name would be "GeoIP2-City-Locations-en.csv".
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoIP Enterprise',
+       csvsizerange: '975 MB - 1.06 GB',
+       mmdbsizerange: '341 MB - 350 MB',
+       ipv4range: '8,064,000 - 8,733,000',
+       ipv6range: '2,933,000 - 3,151,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="Enterprise" />

--- a/content/geoip/docs/databases/isp.mdx
+++ b/content/geoip/docs/databases/isp.mdx
@@ -160,6 +160,19 @@ respectively.
   ]}
 />
 
+## Database Sizes
+
+<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+    {
+       databasename: 'GeoIP ISP',
+       csvsizerange: '80.1 MB - 83.4 MB',
+       mmdbsizerange: '14.5 MB - 14.8 MB',
+       ipv4range: '715,000 - 739,000',
+       ipv6range: '248,000 - 264,000'
+    }
+  ]}
+/>
+
 ## Database Changes
 
 <DatabaseChanges product="ISP" />

--- a/content/geoip/docs/databases/isp.mdx
+++ b/content/geoip/docs/databases/isp.mdx
@@ -162,13 +162,13 @@ respectively.
 
 ## Database Sizes
 
-<DatabaseSizes daterange = 'March to June 2024' databasechanges ={[
+<DatabaseSizes daterange = 'March to June 2024' databaseChanges ={[
     {
-       databasename: 'GeoIP ISP',
-       csvsizerange: '80.1 MB - 83.4 MB',
-       mmdbsizerange: '14.5 MB - 14.8 MB',
-       ipv4range: '715,000 - 739,000',
-       ipv6range: '248,000 - 264,000'
+       databaseName: 'GeoIP ISP',
+       csvSizeRange: '80.1 MB - 83.4 MB',
+       mmdbSizeRange: '14.5 MB - 14.8 MB',
+       ipv4Range: '715,000 - 739,000',
+       ipv6Range: '248,000 - 264,000'
     }
   ]}
 />

--- a/content/geoip/geolite2-free-geolocation-data.mdx
+++ b/content/geoip/geolite2-free-geolocation-data.mdx
@@ -11,9 +11,9 @@ import {
 GeoLite2 databases are free IP geolocation databases comparable to, but less
 accurate than,
 [MaxMind’s GeoIP2 databases](https://www.maxmind.com/en/geoip2-databases). The
-[GeoLite2 Country, City, and ASN databases](/static/pdf/GeoLite2-IP-MetaData-Databases-Comparison-Chart.pdf)
-are updated twice weekly, every Tuesday and Friday. GeoLite2 data is also
-available as a web service in the
+[GeoLite2 Country and City databases](/static/pdf/GeoLite2-IP-MetaData-Databases-Comparison-Chart.pdf)
+are updated twice weekly, every Tuesday and Friday. The GeoLite2 ASN database is
+updated daily. GeoLite2 data is also available as a web service in the
 [GeoLite2 Country and GeoLite2 City web services](/static/pdf/GeoLite2-and-GeoIP2-Precision-Web-Services-Comparison.pdf).
 Users of the GeoLite2 web services are limited to 1000 IP address lookups per
 service per day.

--- a/src/components/DatabaseSizes.tsx
+++ b/src/components/DatabaseSizes.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
 
-import { li as Li, p as P, table as Table, td as Td, th as Th, tr as Tr, ul as Ul } from './Mdx';
+import { li as Li, p as P, table as Table, tbody as Tbody, td as Td, th as Th, thead as Thead, tr as Tr, ul as Ul } from './Mdx';
 
 interface IDatabaseSizes {
     databasechanges: {
@@ -55,24 +55,28 @@ const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
       </P>
 
       <Table>
-        <Tr>
-          <Th>
-            Database
-          </Th>
-          <Th>
-            CSV File Size
-          </Th>
-          <Th>
-            MMDB File Size
-          </Th>
-          <Th>
-            IPv4 Networks
-          </Th>
-          <Th>
-            IPv6 Networks
-          </Th>
-        </Tr>
-        {databasechangesItems}
+        <Thead>
+          <Tr>
+            <Th>
+              Database
+            </Th>
+            <Th>
+              CSV File Size
+            </Th>
+            <Th>
+              MMDB File Size
+            </Th>
+            <Th>
+              IPv4 Networks
+            </Th>
+            <Th>
+              IPv6 Networks
+            </Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {databasechangesItems}
+        </Tbody>
       </Table>
 
       <P>

--- a/src/components/DatabaseSizes.tsx
+++ b/src/components/DatabaseSizes.tsx
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types';
+import * as React from 'react';
+
+import { li as Li, p as P, table as Table, td as Td, th as Th, tr as Tr, ul as Ul } from './Mdx';
+
+interface IDatabaseSizes {
+    databasechanges: {
+      csvsizerange: string;
+      databasename: string;
+      ipv4range: string;
+      ipv6range: string;
+      mmdbsizerange: string;
+    }[];
+    daterange: string;
+}
+
+const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
+  const { databasechanges , daterange } = props;
+  const databasechangesItems = databasechanges.map((databasechange) => (
+    <>
+      <Tr>
+        <Td>
+          {databasechange.databasename}
+        </Td>
+        <Td>
+          {databasechange.csvsizerange}
+        </Td>
+        <Td>
+          {databasechange.mmdbsizerange}
+        </Td>
+        <Td>
+          {databasechange.ipv4range}
+        </Td>
+        <Td>
+          {databasechange.ipv6range}
+        </Td>
+      </Tr>
+    </>
+  ));
+  return (
+    <>
+      <P>
+        MaxMind databases can vary in size from release to release. If you are
+        working with file size limitations that are concerning, you should build
+        your integrations to fail gracefully in event of a significant size
+        change.
+      </P>
+
+      <P>
+        From
+        {' '}
+        {daterange}
+        , the database files varied in file size and number of networks as
+        follows:
+      </P>
+
+      <Table>
+        <Tr>
+          <Th>
+            Database
+          </Th>
+          <Th>
+            CSV File Size
+          </Th>
+          <Th>
+            MMDB File Size
+          </Th>
+          <Th>
+            IPv4 Networks
+          </Th>
+          <Th>
+            IPv6 Networks
+          </Th>
+        </Tr>
+        {databasechangesItems}
+      </Table>
+
+      <P>
+        The listed file sizes are for unpacked databases. Databases are
+        downloaded in a compressed format.
+      </P>
+    </>
+  );
+};
+
+DatabaseSizes.propTypes = {
+  databasechanges: PropTypes.array.isRequired,
+  daterange: PropTypes.string.isRequired,
+};
+
+export default DatabaseSizes;

--- a/src/components/DatabaseSizes.tsx
+++ b/src/components/DatabaseSizes.tsx
@@ -15,24 +15,24 @@ interface IDatabaseSizes {
 }
 
 const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
-  const { databasechanges , daterange } = props;
+  const { databaseChanges , dateRange } = props;
   const databaseChangesItems = databaseChanges.map((databaseChange) => (
     <>
       <Tr>
         <Td>
-          {databasechange.databasename}
+          {databaseChange.databaseName}
         </Td>
         <Td>
-          {databasechange.csvsizerange}
+          {databaseChange.csvSizeRange}
         </Td>
         <Td>
-          {databasechange.mmdbsizerange}
+          {databaseChange.mmdbSizeRange}
         </Td>
         <Td>
-          {databasechange.ipv4range}
+          {databaseChange.ipv4Range}
         </Td>
         <Td>
-          {databasechange.ipv6range}
+          {databaseChange.ipv6Range}
         </Td>
       </Tr>
     </>
@@ -49,7 +49,7 @@ const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
       <P>
         From
         {' '}
-        {daterange}
+        {dateRange}
         , the database files varied in file size and number of networks as
         follows:
       </P>
@@ -75,7 +75,7 @@ const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
           </Tr>
         </Thead>
         <Tbody>
-          {databasechangesItems}
+          {databaseChangesItems}
         </Tbody>
       </Table>
 
@@ -88,8 +88,8 @@ const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
 };
 
 DatabaseSizes.propTypes = {
-  databasechanges: PropTypes.array.isRequired,
-  daterange: PropTypes.string.isRequired,
+  databaseChanges: PropTypes.array.isRequired,
+  dateRange: PropTypes.string.isRequired,
 };
 
 export default DatabaseSizes;

--- a/src/components/DatabaseSizes.tsx
+++ b/src/components/DatabaseSizes.tsx
@@ -16,7 +16,7 @@ interface IDatabaseSizes {
 
 const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {
   const { databasechanges , daterange } = props;
-  const databasechangesItems = databasechanges.map((databasechange) => (
+  const databaseChangesItems = databaseChanges.map((databaseChange) => (
     <>
       <Tr>
         <Td>

--- a/src/components/DatabaseSizes.tsx
+++ b/src/components/DatabaseSizes.tsx
@@ -4,14 +4,14 @@ import * as React from 'react';
 import { li as Li, p as P, table as Table, tbody as Tbody, td as Td, th as Th, thead as Thead, tr as Tr, ul as Ul } from './Mdx';
 
 interface IDatabaseSizes {
-    databasechanges: {
-      csvsizerange: string;
-      databasename: string;
-      ipv4range: string;
-      ipv6range: string;
-      mmdbsizerange: string;
+    databaseChanges: {
+      csvSizeRange: string;
+      databaseName: string;
+      ipv4Range: string;
+      ipv6Range: string;
+      mmdbSizeRange: string;
     }[];
-    daterange: string;
+    dateRange: string;
 }
 
 const DatabaseSizes: React.FC<IDatabaseSizes> = (props) => {

--- a/src/components/Mdx/Tbody.tsx
+++ b/src/components/Mdx/Tbody.tsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const Tbody: React.FC<React.HTMLProps<HTMLTableSectionElement>> = ({ ...props }) => (
+  <tbody
+    {...props}
+  >
+    {props.children}
+  </tbody>
+);
+
+Tbody.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Tbody;

--- a/src/components/Mdx/index.ts
+++ b/src/components/Mdx/index.ts
@@ -40,5 +40,6 @@ export { default as thead } from './Thead';
 export { default as ul } from './Ul';
 export { default as CsvFileExamples } from '../CsvExampleFiles';
 export { default as DatabaseChanges } from '../DatabaseChanges';
+export { default as DatabaseSizes } from '../DatabaseSizes';
 export { default as MmdbFileExamples } from '../MmdbExampleFiles';
 export { default as ZipFileContent } from '../ZipFileContent';

--- a/src/components/Mdx/index.ts
+++ b/src/components/Mdx/index.ts
@@ -33,6 +33,7 @@ export { default as p } from './P';
 export { default as pre } from './Pre';
 export { default as strong } from './Strong';
 export { default as table } from './Table';
+export { default as tbody } from './Tbody';
 export { default as td } from './Td';
 export { default as th } from './Th';
 export { default as tr } from './Tr';


### PR DESCRIPTION
- adds template to record file size and number of network variations over a period of time to database documentation
- uses said template to record variations for 3/24 - 6/24
- updates GeoLite ASN update schedule on the GeoLite page