### PR TITLE
use module script type for global-privacy-control script

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,6 +37,7 @@
   <script
     async
     src="https://www.maxmind.com/js/global-privacy-control.js"
+    type="module"
   ></script>
   {{ template "_internal/opengraph.html" . }}
 </head>


### PR DESCRIPTION
to fix error about using import statement

https://linear.app/maxmind/issue/SCO-7189/gpc-script-works-on-non-www-sites