### PR TITLE
Consistently format text in dev-site geoip web response docs

### DIFF
--- a/content/geoip/docs/web-services/responses.md
+++ b/content/geoip/docs/web-services/responses.md
@@ -715,7 +715,7 @@ address.
   {{< geoip-schema-row key="mobile_country_code" valueType="string" city="true" insights="true">}}
   The [mobile country code (MCC)](https://en.wikipedia.org/wiki/Mobile_country_code) associated with the IP address and ISP.
 
-  This field is not present in the GeoLite City web service.
+  **This field is not present in the GeoLite City web service.**
 
   [Learn more about mobile country code data on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FT6Y6ANRH9GWYXE78B4RXAEX)
   {{</ geoip-schema-row >}}
@@ -723,7 +723,7 @@ address.
   {{< geoip-schema-row key="mobile_network_code" valueType="string" city="true" insights="true">}}
   The [mobile network code (MNC)](https://en.wikipedia.org/wiki/Mobile_country_code) associated with the IP address and ISP.
 
-  This field is not present in the GeoLite City web service.
+  **This field is not present in the GeoLite City web service.**
 
   [Learn more about mobile network code data on our Knowledge Base.](https://support.maxmind.com/hc/en-us/articles/4408200231067-IP-Network-Data#h_01FT6Y6ANRH9GWYXE78B4RXAEX)
   {{</ geoip-schema-row >}}


### PR DESCRIPTION
https://linear.app/maxmind/issue/SCO-7486

The key descriptions in the geoip web response docs sometimes include a note: `This field is not present in the GeoLite City web service`. This note is in bold 5/7 times it appears, but 2 are not bolded. This is likely an oversight and they should be consistent.

For example, [isp](https://dev.maxmind.com/geoip/docs/web-services/responses/#schema--response--traits__isp) has the note in bold, but [mobile_country_code](https://dev.maxmind.com/geoip/docs/web-services/responses/#schema--response--traits__mobile_country_code) below it the note is not bold.

## AC
- geolite city web note is formatted consistently in geoip webservice response docs