### PR TITLE
fix title case and remove 2 from geo products

### DIFF
--- a/content/geoip/release-notes/2024.md
+++ b/content/geoip/release-notes/2024.md
@@ -5,10 +5,10 @@ type: release-note
 outputs: ['html', 'rss']
 ---
 
-{{< release-note date="2024-12-19" title="GeoNames Monthly Diff Report December 2024" >}}
-[GeoNames Monthly Diff Report (December 2024)](/csv-files/GeoNames-Monthly-Diff-Report-December-2024.csv)
+{{< release-note date="2024-12-19" title="GeoNames monthly diff report December 2024" >}}
+[GeoNames monthly diff report (December 2024)](/csv-files/GeoNames-Monthly-Diff-Report-December-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -201,10 +201,10 @@ These changes will be reflected in the following products and services:
 
 {{</ release-note >}}
 
-{{< release-note date="2024-11-14" title="GeoNames Monthly Diff Report November 2024" >}}
-[GeoNames Monthly Diff Report (November 2024)](/csv-files/GeoNames-Monthly-Diff-Report-November-2024.csv)
+{{< release-note date="2024-11-14" title="GeoNames monthly diff report November 2024" >}}
+[GeoNames monthly diff report (November 2024)](/csv-files/GeoNames-Monthly-Diff-Report-November-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -329,10 +329,10 @@ The following products and services will be affected:
 
 {{</ release-note >}}
 
-{{< release-note date="2024-10-11" title="GeoNames Monthly Diff Report October 2024" >}}
-[GeoNames Monthly Diff Report (October 2024)](/csv-files/GeoNames-Monthly-Diff-Report-October-2024.csv)
+{{< release-note date="2024-10-11" title="GeoNames monthly diff report October 2024" >}}
+[GeoNames monthly diff report (October 2024)](/csv-files/GeoNames-Monthly-Diff-Report-October-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -382,10 +382,10 @@ if you have questions or concerns.
 
 {{</ release-note >}}
 
-{{< release-note date="2024-09-10" title="GeoNames Monthly Diff Report September 2024" >}}
-[GeoNames Monthly Diff Report (September 2024)](/csv-files/GeoNames-Monthly-Diff-Report-September-2024.csv)
+{{< release-note date="2024-09-10" title="GeoNames monthly diff report September 2024" >}}
+[GeoNames monthly diff report (September 2024)](/csv-files/GeoNames-Monthly-Diff-Report-September-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -478,10 +478,10 @@ The changes will be reflected in the following products and services:
 
 {{</ release-note >}}
 
-{{< release-note date="2024-08-12" title="GeoNames Monthly Diff Report August 2024" >}}
-[GeoNames Monthly Diff Report (August 2024)](/csv-files/GeoNames-Monthly-Diff-Report-August-2024.csv)
+{{< release-note date="2024-08-12" title="GeoNames monthly diff report August 2024" >}}
+[GeoNames monthly diff report (August 2024)](/csv-files/GeoNames-Monthly-Diff-Report-August-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -563,10 +563,10 @@ services that contain geolocation data, including:
 
 {{</ release-note >}}
 
-{{< release-note date="2024-07-08" title="GeoNames Monthly Diff Report July 2024" >}}
-[GeoNames Monthly Diff Report (July 2024)](/csv-files/GeoNames-Monthly-Diff-Report-July-2024.csv)
+{{< release-note date="2024-07-08" title="GeoNames monthly diff report July 2024" >}}
+[GeoNames monthly diff report (July 2024)](/csv-files/GeoNames-Monthly-Diff-Report-July-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -647,10 +647,10 @@ every Tuesday and Friday.
 
 {{</ release-note >}}
 
-{{< release-note date="2024-06-10" title="GeoNames Monthly Diff Report June 2024" >}}
-[GeoNames Monthly Diff Report (June 2024)](/csv-files/GeoNames-Monthly-Diff-Report-June-2024.csv)
+{{< release-note date="2024-06-10" title="GeoNames monthly diff report June 2024" >}}
+[GeoNames monthly diff report (June 2024)](/csv-files/GeoNames-Monthly-Diff-Report-June-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -672,10 +672,10 @@ differ for the field defined in the `diff_in` column.
 
 {{</ release-note >}}
 
-{{< release-note date="2024-05-09" title="GeoNames Monthly Diff Report May 2024" >}}
-[GeoNames Monthly Diff Report (May 2024)](/csv-files/GeoNames-Monthly-Diff-Report-May-2024.csv)
+{{< release-note date="2024-05-09" title="GeoNames monthly diff report May 2024" >}}
+[GeoNames monthly diff report (May 2024)](/csv-files/GeoNames-Monthly-Diff-Report-May-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -716,10 +716,10 @@ your own local Certificate Authority store.
 
 {{</ release-note >}}
 
-{{< release-note date="2024-04-04" title="GeoNames Monthly Diff Report April 2024" >}}
-[GeoNames Monthly Diff Report (April 2024)](/csv-files/GeoNames-Monthly-Diff-Report-April-2024.csv)
+{{< release-note date="2024-04-04" title="GeoNames monthly diff report April 2024" >}}
+[GeoNames monthly diff report (April 2024)](/csv-files/GeoNames-Monthly-Diff-Report-April-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -744,10 +744,10 @@ place names. A large number of geoname IDs have been updated for Brazil.
 
 {{</ release-note >}}
 
-{{< release-note date="2024-03-18" title="GeoNames Monthly Diff Report March 2024" >}}
-[GeoNames Monthly Diff Report (March 2024)](/csv-files/GeoNames-Monthly-Diff-Report-March-2024.csv)
+{{< release-note date="2024-03-18" title="GeoNames monthly diff report March 2024" >}}
+[GeoNames monthly diff report (March 2024)](/csv-files/GeoNames-Monthly-Diff-Report-March-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -815,14 +815,14 @@ also a minFraud user,
 
 {{</ release-note >}}
 
-{{< release-note date="2024-02-13" title="No GeoNames Monthly Diff Report for February 2024" >}}
+{{< release-note date="2024-02-13" title="No GeoNames monthly diff report for February 2024" >}}
 
 Due to irregularities in the latest GeoNames data, we will be maintaining the
 location names and codes from January.
-[See the Monthly Diff Report for January 2024.](/geoip/release-notes/2024#geonames-monthly-diff-report-january-2024)
+[See the monthly diff report for January 2024.](/geoip/release-notes/2024#geonames-monthly-diff-report-january-2024)
 
 When the irregularities in the GeoNames data are resolved, we will update the
-data and post a new Diff Report.
+data and post a new diff report.
 
 {{</ release-note >}}
 
@@ -832,7 +832,7 @@ To improve our server infrastructure and allow for better performance and
 efficiency, MaxMind will begin enforcing our policies around our API and
 database download requests March 13, 2024. To help customers get ready for this
 change, we will have a planned, temporary enforcement of these policies on
-February 7, 2024.
+February 7, 2024
 
 **What are the policies?**
 
@@ -962,10 +962,10 @@ relevant links below:
 
 {{</ release-note >}}
 
-{{< release-note date="2024-01-08" title="GeoNames Monthly Diff Report January 2024" >}}
-[GeoNames Monthly Diff Report (January 2024)](/csv-files/GeoNames-Monthly-Diff-Report-January-2024.csv)
+{{< release-note date="2024-01-08" title="GeoNames monthly diff report January 2024" >}}
+[GeoNames monthly diff report (January 2024)](/csv-files/GeoNames-Monthly-Diff-Report-January-2024.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/content/geoip/release-notes/2025.md
+++ b/content/geoip/release-notes/2025.md
@@ -50,10 +50,10 @@ This release corrects a small number of identified location accuracy issues.
 
 {{</ release-note >}}
 
-{{< release-note date="2025-05-20" title="GeoNames Monthly Diff Report May 2025" >}}
-[GeoNames Monthly Diff Report (May 2025)](/csv-files/GeoNames-Monthly-Diff-Report-May-2025.csv)
+{{< release-note date="2025-05-20" title="GeoNames monthly diff report May 2025" >}}
+[GeoNames monthly diff report (May 2025)](/csv-files/GeoNames-Monthly-Diff-Report-May-2025.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -151,10 +151,10 @@ These changes will be reflected in the following products and services:
 
 {{</ release-note >}}
 
-{{< release-note date="2025-04-08" title="GeoNames Monthly Diff Report April 2025" >}}
-[GeoNames Monthly Diff Report (April 2025)](/csv-files/GeoNames-Monthly-Diff-Report-April-2025.csv)
+{{< release-note date="2025-04-08" title="GeoNames monthly diff report April 2025" >}}
+[GeoNames monthly diff report (April 2025)](/csv-files/GeoNames-Monthly-Diff-Report-April-2025.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -186,10 +186,10 @@ Any questions, please reach out to the MaxMind support team.
 
 {{</ release-note >}}
 
-{{< release-note date="2025-03-10" title="GeoNames Monthly Diff Report March 2025" >}}
-[GeoNames Monthly Diff Report (March 2025)](/csv-files/GeoNames-Monthly-Diff-Report-March-2025.csv)
+{{< release-note date="2025-03-10" title="GeoNames monthly diff report March 2025" >}}
+[GeoNames monthly diff report (March 2025)](/csv-files/GeoNames-Monthly-Diff-Report-March-2025.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -238,10 +238,10 @@ Monday, February 17, 2025.
 
 {{</ release-note >}}
 
-{{< release-note date="2025-02-11" title="GeoNames Monthly Diff Report February 2025" >}}
-[GeoNames Monthly Diff Report (February 2025)](/csv-files/GeoNames-Monthly-Diff-Report-February-2025.csv)
+{{< release-note date="2025-02-11" title="GeoNames monthly diff report February 2025" >}}
+[GeoNames monthly diff report (February 2025)](/csv-files/GeoNames-Monthly-Diff-Report-February-2025.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
@@ -330,10 +330,10 @@ The field will not be removed from our databases and existing values will contin
 
 {{</ release-note >}}
 
-{{< release-note date="2025-01-09" title="GeoNames Monthly Diff Report January 2025" >}}
-[GeoNames Monthly Diff Report (January 2025)](/csv-files/GeoNames-Monthly-Diff-Report-January-2025.csv)
+{{< release-note date="2025-01-09" title="GeoNames monthly diff report January 2025" >}}
+[GeoNames monthly diff report (January 2025)](/csv-files/GeoNames-Monthly-Diff-Report-January-2025.csv)
 
-GeoIP2 and GeoLite2 databases incorporate
+GeoIP and GeoLite databases incorporate
 [GeoNames geographical data](https://www.geonames.org/), which is made available
 under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
The monthly diff reports were the only remaining release notes with Title Case so I updated going back to January 2024. I also removed the 2 from GeoIP and GeoLite mentioned in the diff reports.