### PR TITLE
Fix boolean comparison in schema-table shortcode

### DIFF
--- a/layouts/shortcodes/schema-table.html
+++ b/layouts/shortcodes/schema-table.html
@@ -19,9 +19,9 @@
         {{ $key := .key }}
         {{ $fragment := printf "schema--response--%s__%s" $parentKey $key }}
         
-        {{ $hasCountry := eq (.country | default "false") "true" }}
-        {{ $hasCity := eq (.city | default "false") "true" }}
-        {{ $hasInsights := eq (.insights | default "false") "true" }}
+        {{ $hasCountry := .country | default false }}
+        {{ $hasCity := .city | default false }}
+        {{ $hasInsights := .insights | default false }}
         
         <tr>
           <td class="schema__key-cell">


### PR DESCRIPTION
The template was comparing boolean values as strings (e.g., `eq (.country | default "false") "true"`),
which broke after the refactor to YAML format where these fields are actual booleans.
Changed to use direct boolean evaluation: `.country | default false`.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
