### PR TITLE
Update web service badge label to "GeoIP City Plus"

### DIFF
--- a/layouts/shortcodes/geoip-schema-row.html
+++ b/layouts/shortcodes/geoip-schema-row.html
@@ -31,7 +31,7 @@
           GeoIP Country
         </span>
         <span class="tag {{ if $hasCity }}tag--checked{{ else }}tag--disabled{{ end }}">
-          GeoIP City
+          GeoIP City Plus
         </span>
         <span class="tag {{ if $hasInsights }}tag--checked{{ else }}tag--disabled{{ end }}">
           GeoIP Insights

--- a/layouts/shortcodes/geoip-schema-row.md
+++ b/layouts/shortcodes/geoip-schema-row.md
@@ -21,7 +21,7 @@
     {{ end }}
     <div>
       <span>{{ if $hasCountry }}✓{{ else }}✗{{ end }} GeoIP Country</span>
-      <span>{{ if $hasCity }}✓{{ else }}✗{{ end }} GeoIP City</span>
+      <span>{{ if $hasCity }}✓{{ else }}✗{{ end }} GeoIP City Plus</span>
       <span>{{ if $hasInsights }}✓{{ else }}✗{{ end }} GeoIP Insights</span>
     </div>
   </td>


### PR DESCRIPTION
## Summary

The `geoip-schema-row` shortcode renders the web service tier badges (GeoIP Country / GeoIP City / GeoIP Insights) on the [GeoIP web service response documentation](content/geoip/docs/web-services/responses.md). The middle badge read **"GeoIP City"**, but the correct product name for that web service is **"GeoIP City Plus"** — which the rest of the site already uses in prose (release notes, response docs, `_index.md`).

This updates the badge label in both the HTML variant and its Markdown output-format counterpart.

## Notes

- The `city="true"` shortcode parameter name is unchanged, so none of the ~64 call-sites in `responses.md` need editing.
- Scope is isolated to the web service docs: `geoip-schema-row` is used only in `responses.md` and never in the GeoIP City **database** docs (those use separate `csv-location-table` / `csv-block-table` badges that correctly read "City"/"Country").

## Verification

Built the site with Hugo and inspected the rendered output of the responses page:
- Rendered HTML: 64 "GeoIP City Plus" badges (39 `tag--checked`, 25 `tag--disabled`), **0** bare "GeoIP City" badges. Country/Insights badges unchanged.
- Rendered Markdown output format matches.
- `precious lint -g` passes (cspell, shortcode-parity, internal-links).

Resolves ENG-4929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)