### PR TITLE
Document anonymizer_confidence value of 50

### DIFF
--- a/content/geoip/docs/databases/anonymous-plus/_index.md
+++ b/content/geoip/docs/databases/anonymous-plus/_index.md
@@ -192,8 +192,9 @@ These are named `GeoIP-Anonymous-Plus-Blocks-IPv4.csv` and
             network is currently part of an actively used VPN service.
           </p>
           <p>
-            Currently we will only provide values of 30 and 99, but the number
-            of values will increase as we improve our confidence ratings.
+            Currently, we will only provide values of 30, 50, and 99, but the
+            number of values will increase as we improve our confidence
+            ratings.
           </p>
           <p>
             <a

--- a/content/geoip/docs/databases/anonymous-plus/binary.md
+++ b/content/geoip/docs/databases/anonymous-plus/binary.md
@@ -26,8 +26,9 @@ network.
             that the network is currently part of an actively used VPN service.
           </p>
           <p>
-            Currently, we will only provide values of 30 and 99, but the number
-            of values will increase as we improve our confidence ratings.
+            Currently, we will only provide values of 30, 50, and 99, but the
+            number of values will increase as we improve our confidence
+            ratings.
           </p>
           <p>
             <a

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -9,6 +9,18 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/geoip-rss-release-notes)
 whenever a new GeoIP release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-06-24" title="A number of networks now have an anonymizer confidence of 50" >}}
+
+As of June 24, 2026, a number of networks have an `anonymizer_confidence` of 50,
+a new value that sits between our existing values of 30 and 99.
+
+This change will be reflected in the following products and services:
+
+- GeoIP Anonymous Plus database
+- GeoIP Insights web service
+
+{{</ release-note >}}
+
 {{< release-note date="2026-06-11" title="City field blanked in selected cities/provinces and countries" >}}
 
 Effective Monday, June 15, 2026, we will be blanking out the city field more


### PR DESCRIPTION
MSLM `medium` confidence now maps to an `anonymizer_confidence` of `50` in GeoIP Anonymous Plus (see STF-405 / [mm_website code change]). This updates the dev docs to match:

- **`anonymous-plus/_index.md`** and **`anonymous-plus/binary.md`**: the `anonymizer_confidence` field description now lists `30, 50, and 99` instead of `30 and 99`.
- **`release-notes/2026.md`**: new release note announcing the `50` value, modeled on the existing `2026-05-05` "confidence of 30" note.

⚠️ **Please confirm the date.** The release note is dated **2026-06-24** based on marketing's reported go-live. Adjust the `date=` and "As of ..." line if that changes.

> Opened by Claude on behalf of @goschwald.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Additional confidence rating level now available in GeoIP Anonymous Plus database and GeoIP Insights web service.

## Documentation
* Updated GeoIP Anonymous Plus documentation to reflect expanded confidence ratings across CSV and binary database formats.
* Added release notes for June 2026 announcing the new rating availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->