### PR TITLE
Update Matomo geolocation FAQ link

### DIFF
--- a/content/geoip/docs/databases.md
+++ b/content/geoip/docs/databases.md
@@ -109,7 +109,7 @@ integrator for assistance. {{</ alert >}}
 | Application                    | Platform                | Link                                                                                                        |
 | ------------------------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Ad-serving                     | Revive Adserver         | [Geotargeting with Revive Adserver](https://www.revive-adserver.com/faq/geotargeting-with-revive-adserver/) |
-| Analytics                      | Piwik/Matomo            | [GEO LOCATE YOUR VISITORS](https://matomo.org/faq/setting-up-accurate-visitors-geolocation/)                |
+| Analytics                      | Piwik/Matomo            | [GEO LOCATE YOUR VISITORS](https://matomo.org/faq/how-to/setting-up-accurate-visitors-geolocation/)         |
 | Analytics                      | Snowplow Analytics      | [IP lookups enrichment](https://github.com/snowplow/snowplow/wiki/IP-lookups-enrichment)                    |
 | Content Delivery               | Varnish Software        | [libvmod-geoip2](https://github.com/varnishcache-friends/libvmod-geoip2)                                    |
 | Database                       | DuckDB                  | [duckdb-maxmind](https://github.com/marselester/duckdb-maxmind)                                             |


### PR DESCRIPTION
The `check-links` CI job failed on a broken link in `content/geoip/docs/databases.md`:

```
[301] https://matomo.org/faq/setting-up-accurate-visitors-geolocation/ | Rejected status code: 301 Moved Permanently
```

Matomo now serves this FAQ under a `how-to/` path and 301-redirects the old URL. Updated the link to the new location:

- **Before:** `https://matomo.org/faq/setting-up-accurate-visitors-geolocation/` → 301
- **After:** `https://matomo.org/faq/how-to/setting-up-accurate-visitors-geolocation/` → 200

Verified locally with `lychee` (✅ OK) and `prettier`/`cspell` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)