### PR TITLE
release note on delayed dbs is posted

### DIFF
--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -9,6 +9,17 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/geoip-rss-release-notes)
 whenever a new GeoIP release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-06-09" title="GeoIP City, GeoLite City, and GeoLite Country databases not released as scheduled today" >}}
+
+The GeoIP database updates for Tuesday, June 9, 2026 for the following databases
+were not released as scheduled:
+
+- GeoIP City database
+- GeoLite City database
+- GeoLite Country database
+
+{{</ release-note >}}
+
 {{< release-note date="2026-05-29" title="GeoIP ISP database and GeoIP Enterprise database release delayed" >}}
 
 The GeoIP database updates for Friday, May 29, 2026 for the following databases

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -11,8 +11,8 @@ whenever a new GeoIP release note is posted. {{</ alert >}}
 
 {{< release-note date="2026-06-09" title="GeoIP City, GeoLite City, and GeoLite Country databases not released as scheduled today" >}}
 
-The GeoIP database updates for Tuesday, June 9, 2026, for the following databases
-were not released as scheduled:
+The GeoIP database updates for Tuesday, June 9, 2026, for the following
+databases were not released as scheduled:
 
 - GeoIP City database
 - GeoLite City database

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -11,7 +11,7 @@ whenever a new GeoIP release note is posted. {{</ alert >}}
 
 {{< release-note date="2026-06-09" title="GeoIP City, GeoLite City, and GeoLite Country databases not released as scheduled today" >}}
 
-The GeoIP database updates for Tuesday, June 9, 2026 for the following databases
+The GeoIP database updates for Tuesday, June 9, 2026, for the following databases
 were not released as scheduled:
 
 - GeoIP City database


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to reflect that GeoIP City, GeoLite City, and GeoLite Country database updates were not released as scheduled on June 9, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->