### PR TITLE
Remove is_in_european_union: false from example json

### DIFF
--- a/content/geoip/docs/web-services/responses.md
+++ b/content/geoip/docs/web-services/responses.md
@@ -442,7 +442,6 @@ believes the end user is located.
 {
   "confidence": 75,
   "geoname_id": 6252001,
-  "is_in_european_union": false,
   "iso_code": "US",
   "names": {
     "de": "USA",
@@ -1144,7 +1143,6 @@ be less accurate. In addition, GeoLite Country requests will not return the
   },
   "country": {
     "geoname_id": 6252001,
-    "is_in_european_union": false,
     "iso_code": "US",
     "names": {
       "de": "USA",
@@ -1228,7 +1226,6 @@ will not return the `maxmind` object.
   },
   "country": {
     "geoname_id": 6252001,
-    "is_in_european_union": false,
     "iso_code": "US",
     "names": {
       "de": "USA",
@@ -1352,7 +1349,6 @@ request.
   },
   "country": {
     "geoname_id": 6252001,
-    "is_in_european_union": false,
     "iso_code": "US",
     "names": {
       "de": "USA",


### PR DESCRIPTION
... because we only include `is_in_european_union` in the response if it is `true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated GeoIP web services response documentation examples to reflect changes in the response schema across Country, City Plus, and Insights services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->