### PR TITLE
Restrict links workflow to contents: read

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,6 @@
 name: Links
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
zizmor reports an `excessive-permissions` finding for the `linkChecker` job in `links.yml`: with no `permissions:` block it inherits the default broad token. The workflow only checks out the repo and runs a link checker, so this grants it the minimal `contents: read` at the workflow level (matching the style of `precious.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal security configuration for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->