### PR TITLE
release note on blankings is posted

### DIFF
--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -23,7 +23,7 @@ This change will result in fewer resolutions in:
 - Riyadh (province)
 
 We will also be blanking out the city field more often for cell networks in the
-United Kingdom. First and second level subdivisions will be retained.
+United Kingdom. First- and second-level subdivisions will be retained.
 
 The update will be reflected in the following products and services:
 

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -9,6 +9,33 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/geoip-rss-release-notes)
 whenever a new GeoIP release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-06-11" title="City field blanked in selected cities/provinces and countries" >}}
+
+Effective Monday, June 15, 2026, we will be blanking out the city field more
+often in the following cities/provinces in Saudi Arabia to reduce false
+positives when the end users of a network are dispersed all over the country.
+
+This change will result in fewer resolutions in:
+
+- Jeddah (city)
+- Riyadh (city)
+- Mecca (province)
+- Riyadh (province)
+
+We will also be blanking out the city field more often for cell networks in the
+United Kingdom. First and second level subdivisions will be retained.
+
+The update will be reflected in the following products and services:
+
+- GeoIP City database
+- GeoIP Enterprise database
+- GeoIP City Plus web service
+- GeoIP Insights web service
+- minFraud Factors web service
+- minFraud Insights web service
+
+{{</ release-note >}}
+
 {{< release-note date="2026-05-29" title="GeoIP ISP database and GeoIP Enterprise database release delayed" >}}
 
 The GeoIP database updates for Friday, May 29, 2026 for the following databases


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes (2026-06-11) for changes effective June 15, 2026: the city field will be blanked more often for selected Saudi Arabia cities/provinces and for UK cell networks, while first- and second-level subdivision data are retained. Affected products: City/Enterprise databases, City Plus/Insights web services, and minFraud web services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->