### PR TITLE
Document HTTP status codes for legacy web services

### DIFF
--- a/content/geoip/docs/databases.md
+++ b/content/geoip/docs/databases.md
@@ -117,7 +117,7 @@ integrator for assistance. {{</ alert >}}
 | Load balancer                  | NGINX                   | [ngx_http_geoip2_module](https://github.com/leev/ngx_http_geoip2_module)                                    |
 | Log Analyzer / Data Processing | Logstash                | [Geoip filter plugin](https://www.elastic.co/docs/reference/logstash/plugins/plugins-filters-geoip)         |
 | Network Protocol Analyzer      | Wireshark               | [How To Use GeoIP With Wireshark](https://gitlab.com/wireshark/wireshark/-/wikis/HowToUseGeoIP)             |
-| Search                         | Elasticsearch           | [GeoIP processor](https://www.elastic.co/docs/reference/enrich-processor/geoip-processor)                   |
+| Search                         | Elasticsearch           | [GeoIP processor](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/geoip-processor.html)        |
 | Web server                     | Caddy                   | [caddy-geoip2](https://github.com/zhangjiayin/caddy-geoip2)                                                 |
 
 ## Command Line (mmdbinspect)

--- a/content/geoip/docs/web-services/legacy.md
+++ b/content/geoip/docs/web-services/legacy.md
@@ -70,6 +70,27 @@ geographically closest to you.
 You must access this service via HTTPS. We require TLS 1.2 or greater for HTTPS
 requests to our servers to keep your data secure.
 
+### HTTP status codes
+
+In addition to the error code returned in the response body, this service uses
+the HTTP status code to indicate certain error conditions. This lets you act on
+these conditions from the HTTP status code, for example in your monitoring or an
+internal proxy, without parsing the response body.
+
+| HTTP status            | Condition                                                                                |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| `200 OK`               | The request was processed. This includes successful lookups and the `IP_NOT_FOUND` case. |
+| `400 Bad Request`      | The request was malformed.                                                               |
+| `401 Unauthorized`     | The license key is missing or invalid (`LICENSE_REQUIRED` or `INVALID_LICENSE_KEY`).     |
+| `402 Payment Required` | Your account has run out of queries.                                                     |
+| `403 Forbidden`        | Your account does not have permission to use this service (`PERMISSION_REQUIRED`).       |
+| `5xx`                  | A server error occurred.                                                                 |
+
+The error code returned in the response body does not always match the HTTP
+status code. When your account has run out of queries, the response body returns
+the `INVALID_LICENSE_KEY` error code even though the HTTP status is `402 Payment
+Required`. The `IP_NOT_FOUND` case returns a `200 OK` status.
+
 ### Output
 
 All services return data as a set of comma-separated fields. The ISP name,

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -9,6 +9,26 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/geoip-rss-release-notes)
 whenever a new GeoIP release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-06-30" title="GeoIP Legacy web service now returns HTTP status codes for errors" >}}
+
+The GeoIP Legacy web service now returns meaningful HTTP status codes for error
+conditions, so you can act on them in your monitoring or an internal proxy,
+without parsing the response body:
+
+- `400 Bad Request` for a malformed request
+- `401 Unauthorized` for a missing or invalid license key
+- `402 Payment Required` when your account is out of queries
+- `403 Forbidden` when your account does not have permission to use the service
+- `5xx` for a server error
+
+The response body and its error-code strings are unchanged. The `IP_NOT_FOUND`
+case continues to return a `200 OK` status to avoid breaking existing
+integrations.
+
+[See the GeoIP Legacy documentation for details.](/geoip/docs/web-services/legacy/#http-status-codes)
+
+{{</ release-note >}}
+
 {{< release-note date="2026-06-24" title="A number of networks now have an anonymizer confidence of 50" >}}
 
 As of June 24, 2026, a number of networks have an `anonymizer_confidence` of 50,

--- a/content/minfraud/minfraud-legacy.md
+++ b/content/minfraud/minfraud-legacy.md
@@ -61,6 +61,26 @@ HTTP, you will receive a `403 Forbidden` HTTP response.
 We require TLS 1.2 or greater for all requests to our servers to keep your data
 secure.
 
+### HTTP status codes
+
+In addition to the error code returned in the response body, this service uses
+the HTTP status code to indicate certain error conditions. This lets you act on
+these conditions from the HTTP status code, for example in your monitoring or an
+internal proxy, without parsing the response body.
+
+| HTTP status            | Condition                                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `200 OK`               | The request was processed. This includes successful lookups and lookups that return a warning code in the response body. |
+| `400 Bad Request`      | The request was malformed.                                                                                               |
+| `401 Unauthorized`     | The license key is missing or invalid (`LICENSE_REQUIRED` or `INVALID_LICENSE_KEY`).                                     |
+| `402 Payment Required` | Your account is out of queries (`MAX_REQUESTS_REACHED`).                                                                 |
+| `403 Forbidden`        | Your account does not have permission to use this service (`PERMISSION_REQUIRED`).                                       |
+| `5xx`                  | A server error occurred.                                                                                                 |
+
+Where applicable, the response body returns an `err` value with the relevant
+error code. Warning conditions, including `IP_NOT_FOUND`, return a `200 OK`
+status.
+
 ### Input
 
 The minFraud API accepts input in a query string or as a form post

--- a/content/minfraud/proxy-detection.md
+++ b/content/minfraud/proxy-detection.md
@@ -46,6 +46,25 @@ HTTP, you will receive a `403 Forbidden` HTTP response.
 We require TLS 1.2 or greater for all requests to our servers to keep your data
 secure.
 
+## HTTP status codes
+
+In addition to the error code returned in the `err` field of the response body,
+this service uses the HTTP status code to indicate certain error conditions.
+This lets you act on these conditions from the HTTP status code, for example in
+your monitoring or an internal proxy, without parsing the response body.
+
+| HTTP status            | Condition                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| `200 OK`               | The request was processed.                                                           |
+| `400 Bad Request`      | The request was malformed.                                                           |
+| `401 Unauthorized`     | The license key is missing or invalid (`LICENSE_REQUIRED` or `INVALID_LICENSE_KEY`). |
+| `402 Payment Required` | Your account is out of queries (`MAX_REQUESTS_REACHED`).                             |
+| `403 Forbidden`        | Your account does not have permission to use this service (`PERMISSION_REQUIRED`).   |
+| `5xx`                  | A server error occurred.                                                             |
+
+Where applicable, the response body returns an `err` value with the relevant
+error code.
+
 ## Input
 
 The API requires you to pass a set of parameters as an HTTP GET or POST. Results

--- a/content/minfraud/proxy-detection.md
+++ b/content/minfraud/proxy-detection.md
@@ -167,8 +167,7 @@ All strings are returned as ASCII.
             </li>
             <li>
               <code>MAX_REQUESTS_REACHED</code> – This error will be returned if
-              your account is out of queries or if an invalid license key is
-              provided.
+              your account is out of queries.
             </li>
           </ul>
         </td>

--- a/content/minfraud/release-notes/2026.md
+++ b/content/minfraud/release-notes/2026.md
@@ -9,6 +9,30 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/minfraud-rss-release-notes)
 whenever a new minFraud release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-06-30" title="minFraud Legacy and Proxy Detection web services now return HTTP status codes for errors" >}}
+
+The minFraud Legacy and Proxy Detection web services now return meaningful HTTP
+status codes for error conditions, so you can act on them in your monitoring or
+an internal proxy, without parsing the response body:
+
+- `400 Bad Request` for a malformed request
+- `401 Unauthorized` for a missing or invalid license key
+- `402 Payment Required` when your account is out of queries
+- `403 Forbidden` when your account does not have permission to use the service
+- `5xx` for a server error
+
+The response body and its error-code strings are unchanged, and a valid IP that
+isn't in our database still returns a `200 OK` status (with a warning in the
+response body). Note that Proxy Detection now returns `400 Bad Request` for a
+malformed request, such as a missing or invalid IP address, that previously
+returned `200 OK`.
+
+[See the minFraud Legacy](/minfraud/minfraud-legacy/#http-status-codes) and
+[Proxy Detection](/minfraud/proxy-detection/#http-status-codes) documentation
+for details.
+
+{{</ release-note >}}
+
 {{< release-note date="2026-05-13" title="Improved readability of the risk reasons module within Transactions Details screen">}}
 
 Based on user feedback, we have updated the risk reasons module within the


### PR DESCRIPTION
This is the public-docs companion to the MaxMind internal service change tracked
as STF-67 (internal PR #44529). It documents a customer-facing behavior change;
it should be merged only once that change is live in production.

## Customer-facing behavior change

The legacy web services now return meaningful HTTP status codes for
authentication and funds errors. Previously these conditions were reported only
as an error-code string in the response body (with a `200 OK` status). Now:

- **minFraud Legacy** and the shared **proxy detection** path: authentication
  failure -> `401 Unauthorized`; account out of queries -> `402 Payment Required`.
- **GeoIP Legacy**: missing/invalid license key -> `401 Unauthorized`; account
  out of queries -> `402 Payment Required` (newly added).
- **IP-not-found deliberately still returns `200 OK`** (not `404`), to avoid
  breaking existing integrations. Other warnings also continue to return `200`.
- The **response body and its error-code strings are unchanged.** In particular,
  for GeoIP Legacy an out-of-queries condition still returns the body error code
  `INVALID_LICENSE_KEY`; only the HTTP status line changed (now `402`).

This lets customers detect these conditions at the HTTP layer (for example, with
an edge or CDN rule) without parsing the response body.

## Files changed

- `content/geoip/docs/web-services/legacy.md`
- `content/minfraud/minfraud-legacy.md`
- `content/minfraud/proxy-detection.md`

The modern GeoIP2/minFraud REST documentation (`responses.md`) already documents
`401`/`402` and is not affected by this change.

---

Opened by Claude, on Greg's behalf.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “HTTP status codes” sections to GeoIP Legacy, minFraud Legacy, and Proxy Detection documentation.
  * Documented how specific HTTP statuses map to error conditions, and how they relate to existing response-body error codes.
  * Clarified special-case behavior (e.g., warning conditions and valid-but-unknown IP handling).

* **Bug Fixes**
  * Updated Legacy web services to return meaningful HTTP status codes for common error conditions (400/401/402/403/5xx), without changing the response-body error codes.
  * Preserved existing `200 OK` behavior for valid-but-unknown IPs and warning cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->