### PR TITLE
Fix broken residential proxy Wikipedia anchor links

### DIFF
--- a/content/geoip/release-notes/2020.md
+++ b/content/geoip/release-notes/2020.md
@@ -85,7 +85,7 @@ differ for the field defined in the ‘diff_in’ column.
 We have released an additional data point for the
 [GeoIP2 Anonymous IP Database](https://www.maxmind.com/en/geoip-anonymous-ip-database).
 Subscribers can now identify whether an IP address is likely a
-[residential proxy](<https://en.wikipedia.org/wiki/Proxy_server#Residential_proxy_(RESIP)>):
+[residential proxy](https://en.wikipedia.org/wiki/Proxy_server#Residential_proxy):
 
 - is_residential_proxy – 1 if the IP address is on a suspected anonymizing
   network and belongs to a residential ISP. Blank if not.
@@ -107,7 +107,7 @@ We have released an additional output for our web services.
 [GeoIP2 Insights](https://www.maxmind.com/en/geoip-api-web-services),
 [minFraud Insights, and minFraud Factors](https://www.maxmind.com/en/solutions/fraud-prevention/overview)
 customers can now see whether an IP address is likely a
-[residential proxy](<https://en.wikipedia.org/wiki/Proxy_server#Residential_proxy_(RESIP)>):
+[residential proxy](https://en.wikipedia.org/wiki/Proxy_server#Residential_proxy):
 
 - /traits/is_residential_proxy – This is true if the IP address is on a
   suspected anonymizing network and belongs to a residential ISP. Otherwise, the

--- a/content/minfraud/release-notes/2020.md
+++ b/content/minfraud/release-notes/2020.md
@@ -16,7 +16,7 @@ We have released an additional output for our web services.
 [GeoIP Insights](https://www.maxmind.com/en/geoip-api-web-services),
 [minFraud Insights, and minFraud Factors](https://www.maxmind.com/en/solutions/fraud-prevention/overview)
 customers can now see whether an IP address is likely a
-[residential proxy](<https://en.wikipedia.org/wiki/Proxy_server#Residential_proxy_(RESIP)>):
+[residential proxy](https://en.wikipedia.org/wiki/Proxy_server#Residential_proxy):
 
 - `/traits/is_residential_proxy` – This is true if the IP address is on a
   suspected anonymizing network and belongs to a residential ISP. Otherwise, the


### PR DESCRIPTION
## Summary

The link checker CI job was failing because the Wikipedia [Proxy server](https://en.wikipedia.org/wiki/Proxy_server) article's "Residential proxy" section heading no longer includes the `(RESIP)` suffix. The old fragment `#Residential_proxy_(RESIP)` no longer resolves.

The section still exists, so this updates the fragment to the current anchor `#Residential_proxy` rather than removing the links. The angle-bracket URL wrapping was also dropped since it was only needed to escape the parentheses in `(RESIP)`.

## Changes

- `content/geoip/release-notes/2020.md` (2 occurrences)
- `content/minfraud/release-notes/2020.md` (1 occurrence)

## Testing

`precious lint -g` passes, including `check-internal-links` and `prettier-markdown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several release note links for the “residential proxy” reference to point to the current Wikipedia section.
  * Improved consistency across older GeoIP and minFraud release notes by replacing outdated link targets with the newer reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->