### PR TITLE
Update client API examples to current library versions

### DIFF
--- a/content/geoip/geolocate-an-ip/databases.md
+++ b/content/geoip/geolocate-an-ip/databases.md
@@ -117,7 +117,7 @@ System.out.println(country.isoCode());
 
 ```javascript
 // Asynchronous database opening
-const Reader = require('@maxmind/geoip2-node').Reader;
+import { Reader } from '@maxmind/geoip2-node';
 
 Reader.open('/path/to/maxmind-database.mmdb').then((reader) => {
   const response = reader.city('128.101.101.101');
@@ -126,10 +126,10 @@ Reader.open('/path/to/maxmind-database.mmdb').then((reader) => {
 });
 
 // Synchronous database opening
-const fs = require('fs');
-const Reader = require('@maxmind/geoip2-node').Reader;
+import { readFileSync } from 'node:fs';
+import { Reader } from '@maxmind/geoip2-node';
 
-const dbBuffer = fs.readFileSync('/path/to/maxmind-database.mmdb');
+const dbBuffer = readFileSync('/path/to/maxmind-database.mmdb');
 
 // This reader object should be reused across lookups as creation of it is
 // expensive.

--- a/content/geoip/geolocate-an-ip/databases.md
+++ b/content/geoip/geolocate-an-ip/databases.md
@@ -29,7 +29,7 @@ Install-Package MaxMind.GeoIP2
 <dependency>
   <groupId>com.maxmind.geoip2</groupId>
   <artifactId>geoip2</artifactId>
-  <version>5.0.2</version>
+  <version>5.1.0</version>
 </dependency>
 
 // Or install via Gradle
@@ -37,7 +37,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'com.maxmind.geoip2:geoip2:5.0.2'
+  implementation 'com.maxmind.geoip2:geoip2:5.1.0'
 }
 ```
 

--- a/content/geoip/geolocate-an-ip/web-services.md
+++ b/content/geoip/geolocate-an-ip/web-services.md
@@ -105,9 +105,7 @@ WebServiceClient client = new WebServiceClient.Builder(accountId, licenseKey)
 ```
 
 ```javascript
-const WebServiceClient = require('@maxmind/geoip2-node').WebServiceClient;
-// TypeScript:
-// import { WebServiceClient } from '@maxmind/geoip2-node';
+import { WebServiceClient } from '@maxmind/geoip2-node';
 
 const accountId = '10';
 const licenseKey = 'LICENSEKEY';
@@ -234,9 +232,7 @@ try (WebServiceClient client = new WebServiceClient.Builder(accountId, licenseKe
 ```
 
 ```javascript
-const WebServiceClient = require('@maxmind/geoip2-node').WebServiceClient;
-// Typescript:
-// import { WebServiceClient } from '@maxmind/geoip2-node';
+import { WebServiceClient } from '@maxmind/geoip2-node';
 
 const accountId = '10';
 const licenseKey = 'LICENSEKEY';

--- a/content/geoip/geolocate-an-ip/web-services.md
+++ b/content/geoip/geolocate-an-ip/web-services.md
@@ -31,7 +31,7 @@ Install-Package MaxMind.GeoIP2
 <dependency>
   <groupId>com.maxmind.geoip2</groupId>
   <artifactId>geoip2</artifactId>
-  <version>5.0.2</version>
+  <version>5.1.0</version>
 </dependency>
 
 // Or install via Gradle
@@ -39,7 +39,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'com.maxmind.geoip2:geoip2:5.0.2'
+  implementation 'com.maxmind.geoip2:geoip2:5.1.0'
 }
 ```
 

--- a/content/minfraud/evaluate-a-transaction.md
+++ b/content/minfraud/evaluate-a-transaction.md
@@ -797,7 +797,6 @@ System.out.println(client.score(request));
 ```javascript
 import { URL } from 'url'; // Used for order.referrerUri
 import * as minFraud from '@maxmind/minfraud-api-node';
-// const minFraud = require('@maxmind/minfraud-api-node');
 
 // client is reusable
 const client = new minFraud.Client('1234', 'LICENSEKEY');

--- a/content/minfraud/evaluate-a-transaction.md
+++ b/content/minfraud/evaluate-a-transaction.md
@@ -70,7 +70,7 @@ Install-Package MaxMind.MinFraud
 <dependency>
   <groupId>com.maxmind.minfraud</groupId>
   <artifactId>minfraud</artifactId>
-  <version>4.2.0</version>
+  <version>4.3.0</version>
 </dependency>
 
 // Or install via Gradle
@@ -78,7 +78,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'com.maxmind.minfraud:minfraud:4.2.0'
+  implementation 'com.maxmind.minfraud:minfraud:4.3.0'
 }
 ```
 

--- a/content/minfraud/proxy-detection.md
+++ b/content/minfraud/proxy-detection.md
@@ -228,7 +228,7 @@ else {
 ```
 
 ```python
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import requests
@@ -253,10 +253,10 @@ if 'err' in proxy and len(proxy['err']):
     sys.stderr.write("MaxMind returned an error code for the request: %s\n" % proxy['err'])
     sys.exit(1)
 else:
-    print "\nMaxMind Proxy data for %s\n\n" % args.ip
+    print("\nMaxMind Proxy data for %s\n" % args.ip)
     for (key, val) in proxy.items():
-        print "  %-20s  %s" % (key, val)
-    print "\n"
+        print("  %-20s  %s" % (key, val))
+    print("")
 ```
 
 ```php

--- a/content/minfraud/report-a-transaction.md
+++ b/content/minfraud/report-a-transaction.md
@@ -40,7 +40,7 @@ Install-Package MaxMind.MinFraud
 <dependency>
   <groupId>com.maxmind.minfraud</groupId>
   <artifactId>minfraud</artifactId>
-  <version>4.2.0</version>
+  <version>4.3.0</version>
 </dependency>
 
 // Or install via Gradle
@@ -48,7 +48,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'com.maxmind.minfraud:minfraud:4.2.0'
+  implementation 'com.maxmind.minfraud:minfraud:4.3.0'
 }
 ```
 


### PR DESCRIPTION
## What

Refresh the client API code examples so they match the current MaxMind client library releases:

- **Java**: bump the GeoIP2 (`5.0.2` → `5.1.0`) and minFraud (`4.2.0` → `4.3.0`) dependency versions in the Maven/Gradle install snippets.
- **Node.js**: update the examples to ES module `import` syntax, since `@maxmind/geoip2-node` (v7) and `@maxmind/minfraud-api-node` (v9) are now ESM-only (no more `require()`).
- **Python**: fix a Python 2 `print` statement in the proxy-detection example to Python 3 syntax.

The other languages' examples were checked against each library's current release/README and left unchanged where already correct (e.g. the PHP Composer `~3.0` constraints already resolve to the current 3.x releases). Verified with `hugo --gc --minify` (builds clean) and the link checker.
