### PR TITLE
Add https://pagead2.googlesyndication.com to csp

### DIFF
--- a/bin/_headers.config.ts
+++ b/bin/_headers.config.ts
@@ -39,8 +39,14 @@ const config: HeadersConfig = {
 
             // https://developers.google.com/tag-platform/security/guides/csp#google_ads
             'https://*.g.doubleclick.net',
+            'https://ad.doubleclick.net',
+            'https://www.googleadservices.com',
+
+            // GA4 Google Signals and Google Ads remarketing/conversions
+            'https://pagead2.googlesyndication.com',
 
             // Google domains (various TLDs for international support)
+            'https://google.com',
             'https://*.google.com',
           ],
           'default-src': ["'self'"],
@@ -97,6 +103,8 @@ const config: HeadersConfig = {
             // https://developers.google.com/tag-platform/security/guides/csp#google_ads_conversions
             'https://www.googleadservices.com',
             'https://www.google.com',
+            'https://pagead2.googlesyndication.com',
+            'https://googleads.g.doubleclick.net',
 
             // Google Tag Manager
             'https://*.googletagmanager.com',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the site’s Content Security Policy to allow additional Google Ads/GA4 remarketing and conversion traffic, ensuring these ad-related resources can load properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->