### PR TITLE
Document residential sub-object of the anonymizer object

### DIFF
--- a/content/geoip/docs/web-services/responses.md
+++ b/content/geoip/docs/web-services/responses.md
@@ -235,6 +235,9 @@ For full examples of response bodies, select one of the following:
 an anonymizing service or network. This data is available for GeoIP Insights
 only.
 
+The `residential` sub-object may be present even when none of the other
+`anonymizer` fields are populated.
+
 ```json
 {
   "confidence": 99,
@@ -245,7 +248,12 @@ only.
   "is_residential_proxy": true,
   "is_tor_exit_node": true,
   "network_last_seen": "2025-01-15",
-  "provider_name": "nordvpn"
+  "provider_name": "nordvpn",
+  "residential": {
+    "confidence": 82,
+    "network_last_seen": "2026-05-11",
+    "provider_name": "quickshift"
+  }
 }
 ```
 
@@ -322,6 +330,59 @@ only.
   Please note that MaxMind identifies a subset of VPN providers. A current list of VPN providers identified in the Anonymous Plus database is available on request.
 
   [Learn more about VPN provider detection on our Knowledge Base.](https://support.maxmind.com/knowledge-base/articles/anonymizer-and-proxy-data-maxmind)
+  {{</ geoip-schema-row >}}
+
+  {{< geoip-schema-row key="residential" valueType="object" insights="true">}}
+  This object contains data about the residential proxy network associated
+  with the IP address.
+
+  See the [Anonymizer > Residential](#schema--response--anonymizer--residential)
+  section below for details.
+  {{</ geoip-schema-row >}}
+{{</ schema-table >}}
+
+<!-- prettier-ignore-end -->
+
+### Anonymizer > Residential
+
+{{< anchor-target schema--response--anonymizer--residential >}}
+
+`residential` is a JSON object that contains data about the residential proxy
+network associated with the IP address. This data is available for GeoIP
+Insights only.
+
+The `residential` object may be present even when none of the other
+`anonymizer` fields are populated.
+
+```json
+{
+  "confidence": 82,
+  "network_last_seen": "2026-05-11",
+  "provider_name": "quickshift"
+}
+```
+
+<!-- prettier-ignore-start -->
+
+{{< schema-table key="anonymizer--residential" >}}
+  {{< geoip-schema-row key="confidence" valueType="integer" valueTypeNote="min: 1, max: 99" insights="true">}}
+  A score ranging from 1 to 99 that represents our percent confidence that the network is an actively used residential proxy.
+
+  [Learn more about anonymizer confidence on our Knowledge Base.](https://support.maxmind.com/knowledge-base/articles/anonymizer-and-proxy-data-maxmind)
+  {{</ geoip-schema-row >}}
+
+  {{< geoip-schema-row key="network_last_seen" valueType="string" insights="true">}}
+  The last day that the network was sighted in our analysis of residential proxies. This is in the ISO 8601 date format (YYYY-MM-DD).
+
+  [Learn more about anonymizer and proxy detection on our Knowledge Base.](https://support.maxmind.com/knowledge-base/articles/anonymizer-and-proxy-data-maxmind)
+  {{</ geoip-schema-row >}}
+
+  {{< geoip-schema-row key="provider_name" valueType="string" insights="true">}}
+  The name of the residential proxy provider (e.g., `oxylabs`, `smartproxy`) associated with the network.
+
+  Please note that MaxMind identifies a subset of residential proxy providers. A current list of identified providers is available on request.
+
+  [Learn more about residential proxy provider detection on our Knowledge Base.](https://support.maxmind.com/knowledge-base/articles/anonymizer-and-proxy-data-maxmind)
   {{</ geoip-schema-row >}}
 {{</ schema-table >}}
 
@@ -1405,7 +1466,12 @@ request.
     "is_residential_proxy": true,
     "is_tor_exit_node": true,
     "network_last_seen": "2025-01-15",
-    "provider_name": "nordvpn"
+    "provider_name": "nordvpn",
+    "residential": {
+      "confidence": 82,
+      "network_last_seen": "2026-05-11",
+      "provider_name": "quickshift"
+    }
   },
   "traits": {
     "ip_address": "1.2.3.4",

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -9,6 +9,29 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/geoip-rss-release-notes)
 whenever a new GeoIP release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-07-10" title="New residential sub-object added to the anonymizer object" >}}
+
+We have added a `residential` sub-object to the
+[`anonymizer` object](/geoip/docs/web-services/responses/#anonymizer), providing
+data about residential proxy networks:
+
+| new data                                   | description                                                                                                                         |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `anonymizer/residential/confidence`        | A score ranging from 1 to 99 that represents our percent confidence that the network is an actively used residential proxy.         |
+| `anonymizer/residential/network_last_seen` | The last day that the network was sighted in our analysis of residential proxies. This is in the ISO 8601 date format (YYYY-MM-DD). |
+| `anonymizer/residential/provider_name`     | The name of the residential proxy provider associated with the network.                                                             |
+
+The `residential` object may be present even when none of the other `anonymizer`
+fields are populated.
+
+This change will be reflected in the following products and services:
+
+- GeoIP Insights web service
+- minFraud Insights
+- minFraud Factors
+
+{{</ release-note >}}
+
 {{< release-note date="2026-06-30" title="GeoIP Legacy web service now returns HTTP status codes for errors" >}}
 
 The GeoIP Legacy web service now returns meaningful HTTP status codes for error

--- a/content/minfraud/release-notes/2026.md
+++ b/content/minfraud/release-notes/2026.md
@@ -9,6 +9,30 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/minfraud-rss-release-notes)
 whenever a new minFraud release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-07-10" title="New residential sub-object added to the anonymizer object" >}}
+
+We have added a `residential` sub-object to the
+[`anonymizer` object](/geoip/docs/web-services/responses/#anonymizer) returned
+in the `ip_address` object for minFraud Insights and Factors, providing data
+about residential proxy networks:
+
+| new data                                   | description                                                                                                                         |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `anonymizer/residential/confidence`        | A score ranging from 1 to 99 that represents our percent confidence that the network is an actively used residential proxy.         |
+| `anonymizer/residential/network_last_seen` | The last day that the network was sighted in our analysis of residential proxies. This is in the ISO 8601 date format (YYYY-MM-DD). |
+| `anonymizer/residential/provider_name`     | The name of the residential proxy provider associated with the network.                                                             |
+
+The `residential` object may be present even when none of the other `anonymizer`
+fields are populated.
+
+This change will be reflected in the following products and services:
+
+- minFraud Insights
+- minFraud Factors
+- GeoIP Insights web service
+
+{{</ release-note >}}
+
 {{< release-note date="2026-06-30" title="minFraud Legacy and Proxy Detection web services now return HTTP status codes for errors" >}}
 
 The minFraud Legacy and Proxy Detection web services now return meaningful HTTP


### PR DESCRIPTION
## Summary

Documents the new `residential` sub-object of the `anonymizer` object (`confidence`, `network_last_seen`, `provider_name`) in the GeoIP Insights response docs, and adds release notes for both GeoIP and minFraud.

The minFraud responses page inherits the `anonymizer` object through the existing "ip_address is the GeoIP Insights response body" reference, matching how the anonymizer object itself was documented, so no schema changes are needed there.

This should be merged when the web services begin returning the field.

## Validation

cspell, internal-link check, and prettier pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
