### PR TITLE
release note on isp name change is posted

### DIFF
--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -17,12 +17,12 @@ regarding smaller downstream providers.
 As an example, we will observe the change below in the ISP field for some
 networks:
 
-| Current ISP name | Updated ISP name                                        |
-| ---------------- | ------------------------------------------------------- |
-| China Mobile     | Shanghai Mobile Communications                          |
-| China Mobile     | Henan Mobile Communications.                            |
-| China Mobile     | China Mobile Shandong                                   |
-| China Mobile     | China Mobile Hebei                                      |
+| Current ISP name | Updated ISP name               |
+| ---------------- | ------------------------------ |
+| China Mobile     | Shanghai Mobile Communications |
+| China Mobile     | Henan Mobile Communications.   |
+| China Mobile     | China Mobile Shandong          |
+| China Mobile     | China Mobile Hebei             |
 
 We expect to release these changes in new database updates and web service
 requests beginning Tuesday, July 21, 2026.

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -17,10 +17,12 @@ regarding smaller downstream providers.
 As an example, we will observe the change below in the ISP field for some
 networks:
 
-| Current ISP name | Updated ISP name
-|----------------------------------------------------- | | China Mobile |
-Shanghai Mobile Communications | | China Mobile | Henan Mobile Communications |
-| China Mobile | China Mobile Shandong | | China Mobile | China Mobile Hebei |
+| Current ISP name | Updated ISP name                                        |
+| ---------------- | ------------------------------------------------------- |
+| China Mobile     | Shanghai Mobile Communications                          |
+| China Mobile     | Henan Mobile Communications.                            |
+| China Mobile     | China Mobile Shandong                                   |
+| China Mobile     | China Mobile Hebei                                      |
 
 We expect to release these changes in new database updates and web service
 requests beginning Tuesday, July 21, 2026.

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -20,7 +20,7 @@ networks:
 | Current ISP name | Updated ISP name               |
 | ---------------- | ------------------------------ |
 | China Mobile     | Shanghai Mobile Communications |
-| China Mobile     | Henan Mobile Communications.   |
+| China Mobile     | Henan Mobile Communications    |
 | China Mobile     | China Mobile Shandong          |
 | China Mobile     | China Mobile Hebei             |
 

--- a/content/geoip/release-notes/2026.md
+++ b/content/geoip/release-notes/2026.md
@@ -9,6 +9,31 @@ outputs: ['html', 'markdown']
 [Sign up to be notified](https://comms.maxmind.com/geoip-rss-release-notes)
 whenever a new GeoIP release note is posted. {{</ alert >}}
 
+{{< release-note date="2026-07-17" title="Updating the ISP name for a number of networks">}}
+
+We are updating the ISP name for some networks to provide further granularity
+regarding smaller downstream providers.
+
+As an example, we will observe the change below in the ISP field for some
+networks:
+
+| Current ISP name | Updated ISP name
+|----------------------------------------------------- | | China Mobile |
+Shanghai Mobile Communications | | China Mobile | Henan Mobile Communications |
+| China Mobile | China Mobile Shandong | | China Mobile | China Mobile Hebei |
+
+We expect to release these changes in new database updates and web service
+requests beginning Tuesday, July 21, 2026.
+
+These changes will be reflected in the following products and services:
+
+- GeoIP Insights web service
+- GeoIP City Plus web service
+- GeoIP ISP database
+- GeoIP Enterprise database
+
+{{</ release-note >}}
+
 {{< release-note date="2026-07-17" title="New residential sub-object added to the anonymizer object" >}}
 
 We have added a `residential` sub-object to the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GeoIP release notes dated July 17, 2026.
  * Announced more granular ISP naming for certain networks.
  * Updates will begin in supported databases and web services starting July 21, 2026, including the GeoIP Insights web service, GeoIP City Plus web service, GeoIP ISP database, and GeoIP Enterprise database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->